### PR TITLE
Add browser test script

### DIFF
--- a/lib/services/datasets.js
+++ b/lib/services/datasets.js
@@ -8,6 +8,9 @@ var invariant = require('invariant'),
   constants = require('../constants'),
   makeURL = require('../make_url');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var Datasets = module.exports = makeService('MapboxDatasets');
 
 /**

--- a/lib/services/directions.js
+++ b/lib/services/directions.js
@@ -7,6 +7,9 @@ var invariant = require('invariant'),
   makeURL = require('../make_url'),
   constants = require('../constants');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var MapboxDirections = makeService('MapboxDirections');
 
 /**

--- a/lib/services/geocoder.js
+++ b/lib/services/geocoder.js
@@ -6,6 +6,9 @@ var invariant = require('invariant'),
   makeURL = require('../make_url'),
   constants = require('../constants');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var MapboxGeocoder = makeService('MapboxGeocoder');
 
 /**

--- a/lib/services/matching.js
+++ b/lib/services/matching.js
@@ -7,6 +7,9 @@ var invariant = require('invariant'),
   makeURL = require('../make_url'),
   constants = require('../constants');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var MapboxMatching = makeService('MapboxMatching');
 
 /**

--- a/lib/services/surface.js
+++ b/lib/services/surface.js
@@ -7,6 +7,9 @@ var invariant = require('invariant'),
   makeURL = require('../make_url'),
   constants = require('../constants');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var MapboxSurface = makeService('MapboxSurface');
 
 /**

--- a/lib/services/uploads.js
+++ b/lib/services/uploads.js
@@ -6,6 +6,9 @@ var invariant = require('invariant'),
   constants = require('../constants'),
   makeURL = require('../make_url');
 
+// Teach request about our GeoJSON Content-Type
+request.parse['application/vnd.geo+json'] = JSON.parse;
+
 var Uploads = module.exports = makeService('MapboxUploads');
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/client.js",
   "scripts": {
     "lint": "eslint --no-eslintrc -c .eslintrc lib test/*.js",
-    "test": "tap --coverage test/*.js",
+    "test": "tap --coverage test/browser.js test/*.js",
+    "browser-test": "browserify -t envify -t brfs test/browser.js test/*.js | smokestack | tap-status",
     "docs": "documentation . --format=md > API.md",
     "build": "npm run build-dist && npm run build-min",
     "build-dist": "browserify -s MapboxClient lib/client.js > dist/mapbox-sdk.js",
@@ -29,21 +30,28 @@
   "homepage": "https://github.com/mapbox/mapbox-sdk-js",
   "devDependencies": {
     "aws-sdk": "^2.1.41",
+    "brfs": "^1.4.1",
     "browserify": "^11.0.0",
     "documentation": "^2.1.0-alpha2",
+    "envify": "^3.4.0",
     "eslint": "^0.24.1",
     "geojson-random": "^0.2.2",
     "geojsonhint": "^1.1.0",
     "hat": "0.0.3",
     "polyline": "^0.1.0",
+    "smokestack": "^3.3.0",
     "tap": "^1.3.1",
+    "tap-status": "^1.0.1",
     "uglifyjs": "^2.4.10"
   },
   "dependencies": {
+    "browser-process-hrtime": "^0.1.2",
+    "browser-stdout": "https://github.com/tmcw/browser-stdout/archive/allow-label-false.tar.gz",
     "es6-template-strings": "^1.0.0",
     "geojsonhint": "^1.0.1",
     "hat": "0.0.3",
     "invariant": "^2.1.0",
+    "rest": "^1.3.1",
     "superagent": "^1.2.0",
     "xtend": "^4.0.0"
   }

--- a/test/geocode.js
+++ b/test/geocode.js
@@ -2,8 +2,6 @@
 'use strict';
 
 var test = require('tap').test,
-  // fs = require('fs'),
-  // path = require('path'),
   geojsonhint = require('geojsonhint'),
   MapboxClient = require('../lib/services/geocoder');
 

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -5,6 +5,7 @@ var test = require('tap').test;
 var MapboxClient = require('../lib/services/uploads');
 var AWS = require('aws-sdk');
 var hat = require('hat');
+var path = require('path');
 var fs = require('fs');
 
 test('UploadClient', function(uploadClient) {
@@ -46,8 +47,8 @@ test('UploadClient', function(uploadClient) {
         s3.putObject({
           Bucket: credentials.bucket,
           Key: credentials.key,
-          Body: fs.createReadStream(__dirname + '/fixtures/valid-onlytiles.mbtiles')
-        }, function(err, resp) {
+          Body: fs.readFileSync(path.join(__dirname, '/fixtures/valid-onlytiles.mbtiles'))
+        }, function(err /*, resp */) {
           assert.ifError(err, 'success');
           testStagedFiles.push(credentials);
           assert.end();
@@ -168,7 +169,7 @@ test('UploadClient', function(uploadClient) {
     listUploads.test('valid request', function(assert) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created upload client');
-      client.listUploads(function(err, uploads) {
+      client.listUploads(function(err/*, uploads */) {
         assert.ifError(err, 'success');
         assert.end();
       });
@@ -194,7 +195,7 @@ test('UploadClient', function(uploadClient) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created upload client');
       var upload = testUploads.shift();
-      client.deleteUpload(completedUpload.id, function(err, uploads) {
+      client.deleteUpload(completedUpload.id, function(err/*, uploads*/) {
         assert.ifError(err, 'success');
         assert.end();
       });


### PR DESCRIPTION
This adds smokestack and enough polyfill to get node-tap working
browser-side. The tests run, but the upload tests fail partially
through and this new test environment exposes a superagent oddity:
that it's very weak in terms of explicitly parsing responses
into JSON.

Passing to @scothis to test out `rest` as a better replacement
to superagent in this context.