### PR TITLE
Make it possible to specify GET params, and fix geocoder proximity

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2,6 +2,7 @@
 
 var rest = require('rest');
 var callbackify = require('./callbackify');
+var interceptor = require('rest/interceptor');
 
 // rest.js client with MIME support
 module.exports = function(config) {
@@ -12,6 +13,11 @@ module.exports = function(config) {
     .wrap(require('rest/interceptor/defaultRequest'), {
       params: { access_token: config.accessToken }
     })
+    .wrap(interceptor({ request: function(request, config) {
+        // if there are any explicitly-marked get parameters, stick them in 'params' now that interpolation is done
+        if (request.getParams) request.params = request.getParams;
+        return request;
+     }}))
     .wrap(require('rest/interceptor/template'))
     .wrap(callbackify);
 };

--- a/lib/services/geocoder.js
+++ b/lib/services/geocoder.js
@@ -53,12 +53,13 @@ MapboxGeocoder.prototype.geocodeForward = function(query, options, callback) {
     query: query,
     dataset: 'mapbox.places'
   };
+  var getOptions = {};
 
   if (options.proximity) {
     assert(typeof options.proximity.latitude === 'number' &&
       typeof options.proximity.longitude === 'number',
       'proximity must be an object with numeric latitude & longitude properties');
-    queryOptions.proximity = options.proximity.longitude + ',' + options.proximity.latitude;
+    getOptions.proximity = options.proximity.longitude + ',' + options.proximity.latitude;
   }
 
   if (options.dataset) {
@@ -69,6 +70,7 @@ MapboxGeocoder.prototype.geocodeForward = function(query, options, callback) {
   this.client({
     path: constants.API_GEOCODER_FORWARD,
     params: queryOptions,
+    getParams: getOptions,
     callback: callback
   });
 };


### PR DESCRIPTION
The rest template interceptor deletes params after template interpolation, so params intended to be GET parameters never get used. This adds a separate "getParams" option that the template interceptor doesn't touch, and makes the geocoder use it, to fix #54 .

If we don't want to go this direction, the other options are either to not use the template interceptor at all and depend on UriBuilder instead, which doesn't have this problem but is apparently deficient in other ways as suggested by the rest docs, or to fork the template interceptor and change its behavior in this respect.

cc @tmcw 