### PR TITLE
Add proximity GET parameter to forward geocoding template

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,7 +2,7 @@
 // place, so that we could concievably update this for API layout
 // revisions.
 module.exports.DEFAULT_ENDPOINT = 'https://api.mapbox.com';
-module.exports.API_GEOCODER_FORWARD = '/geocoding/v5/{dataset}/{query}.json';
+module.exports.API_GEOCODER_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity}';
 module.exports.API_GEOCODER_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json';
 module.exports.API_DIRECTIONS = '/v4/directions/{profile}/{encodedWaypoints}.json';
 module.exports.API_DISTANCE = '/distances/v1/mapbox/{profile}';


### PR DESCRIPTION
Per #55, I can add expected GET parameters to the template, so doing that rather than hacking around in the interceptor.

I think this one is uncontroversial, so I'm gonna merge unless anyone has objections?