### PR TITLE
Configurably round reverse geocoding requests to 5 places, and proximity requests to 3

### DIFF
--- a/lib/services/geocoder.js
+++ b/lib/services/geocoder.js
@@ -6,6 +6,9 @@ var assert = require('assert'),
 
 var MapboxGeocoder = makeService('MapboxGeocoder');
 
+var REVERSE_GEOCODER_PRECISION = 5;
+var FORWARD_GEOCODER_PROXIMITY_PRECISION = 3;
+
 /**
  * Search for a location with a string, using the
  * [Mapbox Geocoding API](https://www.mapbox.com/developers/api/geocoding/).
@@ -54,11 +57,17 @@ MapboxGeocoder.prototype.geocodeForward = function(query, options, callback) {
     dataset: 'mapbox.places'
   };
 
+  var precision = FORWARD_GEOCODER_PROXIMITY_PRECISION;
+  if (options.precision) {
+    assert(typeof options.precision === 'number', 'precision option must be number');
+    precision = options.precision;
+  }
+
   if (options.proximity) {
     assert(typeof options.proximity.latitude === 'number' &&
       typeof options.proximity.longitude === 'number',
       'proximity must be an object with numeric latitude & longitude properties');
-    queryOptions.proximity = options.proximity.longitude + ',' + options.proximity.latitude;
+    queryOptions.proximity = roundTo(options.proximity.longitude, precision) + ',' + roundTo(options.proximity.latitude, precision);
   }
 
   if (options.dataset) {
@@ -119,15 +128,26 @@ MapboxGeocoder.prototype.geocodeReverse = function(location, options, callback) 
     dataset = options.dataset;
   }
 
+  var precision = REVERSE_GEOCODER_PRECISION;
+  if (options.precision) {
+    assert(typeof options.precision === 'number', 'precision option must be number');
+    precision = options.precision;
+  }
+
   this.client({
     path: constants.API_GEOCODER_REVERSE,
     params: {
-      longitude: location.longitude,
-      latitude: location.latitude,
+      longitude: roundTo(location.longitude, precision),
+      latitude: roundTo(location.latitude, precision),
       dataset: dataset
     },
     callback: callback
   });
 };
+
+function roundTo(value, places) {
+  var mult = Math.pow(10, places);
+  return Math.round(value * mult) / mult;
+}
 
 module.exports = MapboxGeocoder;

--- a/test/geocode.js
+++ b/test/geocode.js
@@ -59,6 +59,47 @@ test('MapboxClient#geocodeForward', function(t) {
     });
   });
 
+  t.test('options.proximity rounding', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+
+    var tester = { client: function(opts) {
+      opts.params.proximity.split(',').forEach(function(coord, i) {
+        t.ok(coord.toString().split('.')[1].length <= 3, 'proximity coordinate [' + i + '] precision <= 3');
+      });
+      t.ok(opts.params.proximity, 'proximity is set')
+      opts.callback();
+    }};
+
+    t.ok(client);
+    client.geocodeForward.apply(tester, ['Paris', {
+      proximity: { latitude: 33.6875431, longitude: -95.4431142 }
+    }, function(err, results) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
+  t.test('options.proximity rounding, precision = 1', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+
+    var tester = { client: function(opts) {
+      opts.params.proximity.split(',').forEach(function(coord, i) {
+        t.ok(coord.toString().split('.')[1].length <= 1, 'proximity coordinate [' + i + '] precision <= 1');
+      });
+      t.ok(opts.params.proximity, 'proximity is set')
+      opts.callback();
+    }};
+
+    t.ok(client);
+    client.geocodeForward.apply(tester, ['Paris', {
+      proximity: { latitude: 33.6875431, longitude: -95.4431142 },
+      precision: 1
+    }, function(err, results) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
   t.end();
 });
 
@@ -102,6 +143,52 @@ test('MapboxClient#geocodeReverse', function(t) {
       t.deepEqual(geojsonhint.hint(results), [], 'results are valid');
       t.end();
     });
+  });
+
+  t.test('reverse coordinate rounding', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+
+    var tester = { client: function(opts) {
+      [opts.params.longitude, opts.params.latitude].forEach(function(coord, i) {
+        t.ok(coord.toString().split('.')[1].length <= 5, 'reverse coordinate [' + i + '] precision <= 5');
+      });
+      t.ok(opts.params.longitude, 'longitude is set')
+      t.ok(opts.params.latitude, 'latitude is set')
+      opts.callback();
+    }};
+
+    t.ok(client);
+    client.geocodeReverse.apply(tester, [{
+      latitude: 33.6875431,
+      longitude: -95.4431142
+    }, function(err, results) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
+  t.test('reverse coordinate precision = 2', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+
+    var tester = { client: function(opts) {
+      [opts.params.longitude, opts.params.latitude].forEach(function(coord, i) {
+        t.ok(coord.toString().split('.')[1].length <= 2, 'reverse coordinate [' + i + '] precision <= 2');
+      });
+      t.ok(opts.params.longitude, 'longitude is set')
+      t.ok(opts.params.latitude, 'latitude is set')
+      opts.callback();
+    }};
+
+    t.ok(client);
+    client.geocodeReverse.apply(tester, [{
+      latitude: 33.6875431,
+      longitude: -95.4431142
+    }, {
+      precision: 2
+    }, function(err, results) {
+      t.ifError(err);
+      t.end();
+    }]);
   });
 
   t.end();


### PR DESCRIPTION
This nudges reverse geocodes to 5 places (~.5-meter max error) and proximity parameters in forward geocodes to 3 places (~50 meter max error) to improve performance by increasing cache hit rates, and adds corresponding tests.

cc @sbma44