### PR TITLE
add datasets back to readme with disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Contact help@mapbox.com for information
 * [Surface API](https://www.mapbox.com/developers/api/surface/)
   * Interpolates values along lines. Useful for elevation traces.
 
+Not currently public
+
+* Datasets
+  * Retrieve, add, and edit datasets.
+  * **Note: The Mapbox Datasets API is in private beta. Currently, all end user requests to this API from outside of Mapbox will 404.**
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
About once per week we get a support request from a user using this SDK wondering why their Datasets API call 404'd. This PR adds Datasets back to the README and explains why requests to it won't work (instead of removing real methods in the SDK from `API.md`).

cc @tmcw @tristen 