### PR TITLE
Support `types` & `country` params when geocoding

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,8 +2,8 @@
 // place, so that we could concievably update this for API layout
 // revisions.
 module.exports.DEFAULT_ENDPOINT = 'https://api.mapbox.com';
-module.exports.API_GEOCODER_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity}';
-module.exports.API_GEOCODER_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json';
+module.exports.API_GEOCODER_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity,country,types}';
+module.exports.API_GEOCODER_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json{?types}';
 module.exports.API_DIRECTIONS = '/v4/directions/{profile}/{encodedWaypoints}.json{?alternatives,instructions,geometry,steps}';
 module.exports.API_DISTANCE = '/distances/v1/mapbox/{profile}';
 module.exports.API_SURFACE = '/v4/surface/{mapid}.json{?layer,fields,points,geojson,interpolate,encoded_polyline}';

--- a/lib/services/geocoder.js
+++ b/lib/services/geocoder.js
@@ -9,6 +9,11 @@ var MapboxGeocoder = makeService('MapboxGeocoder');
 var REVERSE_GEOCODER_PRECISION = 5;
 var FORWARD_GEOCODER_PROXIMITY_PRECISION = 3;
 
+function roundTo(value, places) {
+  var mult = Math.pow(10, places);
+  return Math.round(value * mult) / mult;
+}
+
 /**
  * Search for a location with a string, using the
  * [Mapbox Geocoding API](https://www.mapbox.com/developers/api/geocoding/).
@@ -20,6 +25,11 @@ var FORWARD_GEOCODER_PROXIMITY_PRECISION = 3;
  * a geographical point given as an object with latitude and longitude
  * properties. Search results closer to this point will be given
  * higher priority.
+ * @param {string} options.types a comma seperated list of types that filter
+ * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
+ * for available types.
+ * @param {string} options.country a comma seperated list of country codes to
+ * limit results to specified country or countries.
  * @param {string} [options.dataset=mapbox.places] the desired data to be
  * geocoded against. The default, mapbox.places, does not permit unlimited
  * caching. `mapbox.places-permanent` is available on request and does
@@ -75,6 +85,16 @@ MapboxGeocoder.prototype.geocodeForward = function(query, options, callback) {
     queryOptions.dataset = options.dataset;
   }
 
+  if (options.country) {
+    assert(typeof options.country === 'string', 'country option must be string');
+    queryOptions.country = options.country;
+  }
+
+  if (options.types) {
+    assert(typeof options.types === 'string', 'types option must be string');
+    queryOptions.types = options.types;
+  }
+
   this.client({
     path: constants.API_GEOCODER_FORWARD,
     params: queryOptions,
@@ -90,7 +110,10 @@ MapboxGeocoder.prototype.geocodeForward = function(query, options, callback) {
  * @param {number} location.latitude decimal degrees latitude, in range -90 to 90
  * @param {number} location.longitude decimal degrees longitude, in range -180 to 180
  * @param {Object} [options={}] additional options meant to tune
- * the request
+ * the request.
+ * @param {string} options.types a comma seperated list of types that filter
+ * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
+ * for available types.
  * @param {string} [options.dataset=mapbox.places] the desired data to be
  * geocoded against. The default, mapbox.places, does not permit unlimited
  * caching. `mapbox.places-permanent` is available on request and does
@@ -122,10 +145,13 @@ MapboxGeocoder.prototype.geocodeReverse = function(location, options, callback) 
     typeof location.longitude === 'number',
     'location must be an object with numeric latitude & longitude properties');
 
-  var dataset = 'mapbox.places';
+  var queryOptions = {
+    dataset: 'mapbox.places'
+  };
+
   if (options.dataset) {
     assert(typeof options.dataset === 'string', 'dataset option must be string');
-    dataset = options.dataset;
+    queryOptions.dataset = options.dataset;
   }
 
   var precision = REVERSE_GEOCODER_PRECISION;
@@ -134,20 +160,19 @@ MapboxGeocoder.prototype.geocodeReverse = function(location, options, callback) 
     precision = options.precision;
   }
 
+  if (options.types) {
+    assert(typeof options.types === 'string', 'types option must be string');
+    queryOptions.types = options.types;
+  }
+
+  queryOptions.longitude = roundTo(location.longitude, precision);
+  queryOptions.latitude = roundTo(location.latitude, precision);
+
   this.client({
     path: constants.API_GEOCODER_REVERSE,
-    params: {
-      longitude: roundTo(location.longitude, precision),
-      latitude: roundTo(location.latitude, precision),
-      dataset: dataset
-    },
+    params: queryOptions,
     callback: callback
   });
 };
-
-function roundTo(value, places) {
-  var mult = Math.pow(10, places);
-  return Math.round(value * mult) / mult;
-}
 
 module.exports = MapboxGeocoder;

--- a/test/geocode.js
+++ b/test/geocode.js
@@ -47,6 +47,42 @@ test('MapboxClient#geocodeForward', function(t) {
     });
   });
 
+  t.test('options.country', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+
+    var tester = { client: function(opts) {
+      var params = opts.params;
+      t.equals(params.country, 'ca', 'country option is set');
+      opts.callback();
+    }};
+
+    client.geocodeForward.apply(tester, ['Paris', {
+      country: 'ca'
+    }, function(err) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
+  t.test('options.types', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+
+    var tester = { client: function(opts) {
+      var params = opts.params;
+      t.equals(params.types, 'country,region', 'types option is set');
+      opts.callback();
+    }};
+
+    client.geocodeForward.apply(tester, ['Paris', {
+      types: 'country,region'
+    }, function(err) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
   t.test('options.proximity', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
@@ -66,14 +102,14 @@ test('MapboxClient#geocodeForward', function(t) {
       opts.params.proximity.split(',').forEach(function(coord, i) {
         t.ok(coord.toString().split('.')[1].length <= 3, 'proximity coordinate [' + i + '] precision <= 3');
       });
-      t.ok(opts.params.proximity, 'proximity is set')
+      t.ok(opts.params.proximity, 'proximity is set');
       opts.callback();
     }};
 
     t.ok(client);
     client.geocodeForward.apply(tester, ['Paris', {
       proximity: { latitude: 33.6875431, longitude: -95.4431142 }
-    }, function(err, results) {
+    }, function(err) {
       t.ifError(err);
       t.end();
     }]);
@@ -86,7 +122,7 @@ test('MapboxClient#geocodeForward', function(t) {
       opts.params.proximity.split(',').forEach(function(coord, i) {
         t.ok(coord.toString().split('.')[1].length <= 1, 'proximity coordinate [' + i + '] precision <= 1');
       });
-      t.ok(opts.params.proximity, 'proximity is set')
+      t.ok(opts.params.proximity, 'proximity is set');
       opts.callback();
     }};
 
@@ -94,7 +130,7 @@ test('MapboxClient#geocodeForward', function(t) {
     client.geocodeForward.apply(tester, ['Paris', {
       proximity: { latitude: 33.6875431, longitude: -95.4431142 },
       precision: 1
-    }, function(err, results) {
+    }, function(err) {
       t.ifError(err);
       t.end();
     }]);
@@ -132,7 +168,26 @@ test('MapboxClient#geocodeReverse', function(t) {
     });
   });
 
-  t.test('dataset option', function(t) {
+  t.test('options.types', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+
+    var tester = { client: function(opts) {
+      var params = opts.params;
+      t.equals(params.types, 'country,region', 'types option is set');
+      opts.callback();
+    }};
+
+    client.geocodeReverse.apply(tester, [
+    { latitude: 33.6875431, longitude: -95.4431142 },
+    { types: 'country,region' },
+    function(err) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
+  t.test('options.dataset', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
     client.geocodeReverse(
@@ -152,8 +207,8 @@ test('MapboxClient#geocodeReverse', function(t) {
       [opts.params.longitude, opts.params.latitude].forEach(function(coord, i) {
         t.ok(coord.toString().split('.')[1].length <= 5, 'reverse coordinate [' + i + '] precision <= 5');
       });
-      t.ok(opts.params.longitude, 'longitude is set')
-      t.ok(opts.params.latitude, 'latitude is set')
+      t.ok(opts.params.longitude, 'longitude is set');
+      t.ok(opts.params.latitude, 'latitude is set');
       opts.callback();
     }};
 
@@ -161,7 +216,7 @@ test('MapboxClient#geocodeReverse', function(t) {
     client.geocodeReverse.apply(tester, [{
       latitude: 33.6875431,
       longitude: -95.4431142
-    }, function(err, results) {
+    }, function(err) {
       t.ifError(err);
       t.end();
     }]);
@@ -174,8 +229,8 @@ test('MapboxClient#geocodeReverse', function(t) {
       [opts.params.longitude, opts.params.latitude].forEach(function(coord, i) {
         t.ok(coord.toString().split('.')[1].length <= 2, 'reverse coordinate [' + i + '] precision <= 2');
       });
-      t.ok(opts.params.longitude, 'longitude is set')
-      t.ok(opts.params.latitude, 'latitude is set')
+      t.ok(opts.params.longitude, 'longitude is set');
+      t.ok(opts.params.latitude, 'latitude is set');
       opts.callback();
     }};
 
@@ -185,7 +240,7 @@ test('MapboxClient#geocodeReverse', function(t) {
       longitude: -95.4431142
     }, {
       precision: 2
-    }, function(err, results) {
+    }, function(err) {
       t.ifError(err);
       t.end();
     }]);


### PR DESCRIPTION
- Add option for `types` in geocodeReverse & geocodeForward
- Add option for `country` in geocodeForward
- Lint text/geocode.js & lib/services/geocoder.js

Closes #64