### PR TITLE
Promise support sketch

### DIFF
--- a/lib/services/datasets.js
+++ b/lib/services/datasets.js
@@ -40,15 +40,13 @@ var Datasets = module.exports = makeService('MapboxDatasets');
  * });
  */
 Datasets.prototype.listDatasets = function(callback) {
-  invariant(typeof callback === 'function', 'callback must be a function');
-
-  this.client({
+  return this.client({
     path: constants.API_DATASET_DATASETS,
     params: {
       owner: this.owner
     },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -83,16 +81,15 @@ Datasets.prototype.createDataset = function(options, callback) {
   }
 
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_DATASETS,
     params: {
       owner: this.owner
     },
     entity: options,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -119,16 +116,15 @@ Datasets.prototype.createDataset = function(options, callback) {
  */
 Datasets.prototype.readDataset = function(dataset, callback) {
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_DATASET,
     params: {
       owner: this.owner,
       dataset: dataset
     },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -159,11 +155,10 @@ Datasets.prototype.readDataset = function(dataset, callback) {
  */
 Datasets.prototype.updateDataset = function(dataset, options, callback) {
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(typeof options === 'object', 'options must be an object');
   invariant(!!options.name || !!options.description, 'options must include a name or a description');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_DATASET,
     params: {
       owner: this.owner,
@@ -172,7 +167,7 @@ Datasets.prototype.updateDataset = function(dataset, options, callback) {
     method: 'patch',
     entity: options,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -191,9 +186,8 @@ Datasets.prototype.updateDataset = function(dataset, options, callback) {
  */
 Datasets.prototype.deleteDataset = function(dataset, callback) {
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_DATASET,
     params: {
       owner: this.owner,
@@ -201,7 +195,7 @@ Datasets.prototype.deleteDataset = function(dataset, callback) {
     },
     method: 'delete',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -248,7 +242,6 @@ Datasets.prototype.listFeatures = function(dataset, options, callback) {
 
   invariant(typeof dataset === 'string', 'dataset must be a string');
   invariant(typeof options === 'object', 'options must be a object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var params = {
     owner: this.owner,
@@ -270,11 +263,11 @@ Datasets.prototype.listFeatures = function(dataset, options, callback) {
     params.start = options.start;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_FEATURES,
     params: params,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -353,13 +346,12 @@ Datasets.prototype.listFeatures = function(dataset, options, callback) {
  */
 Datasets.prototype.insertFeature = function(feature, dataset, callback) {
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(geojsonhint.hint(feature).length === 0, 'feature must be valid GeoJSON');
 
   var id = feature.id || hat();
   invariant(typeof id === 'string', 'The GeoJSON feature\'s id must be a string');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_FEATURE,
     params: {
       owner: this.owner,
@@ -369,7 +361,7 @@ Datasets.prototype.insertFeature = function(feature, dataset, callback) {
     method: 'put',
     entity: feature,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -401,9 +393,8 @@ Datasets.prototype.insertFeature = function(feature, dataset, callback) {
 Datasets.prototype.readFeature = function(id, dataset, callback) {
   invariant(typeof id === 'string', 'id must be a string');
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_FEATURE,
     params: {
       owner: this.owner,
@@ -411,7 +402,7 @@ Datasets.prototype.readFeature = function(id, dataset, callback) {
       id: id
     },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -432,9 +423,8 @@ Datasets.prototype.readFeature = function(id, dataset, callback) {
 Datasets.prototype.deleteFeature = function(id, dataset, callback) {
   invariant(typeof id === 'string', 'id must be a string');
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_FEATURE,
     params: {
       owner: this.owner,
@@ -443,7 +433,7 @@ Datasets.prototype.deleteFeature = function(id, dataset, callback) {
     },
     method: 'delete',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -529,7 +519,6 @@ Datasets.prototype.deleteFeature = function(id, dataset, callback) {
 Datasets.prototype.batchFeatureUpdate = function(update, dataset, callback) {
   invariant(typeof update === 'object', 'update must be an object');
   invariant(typeof dataset === 'string', 'dataset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var inserts = update.put || [];
   var deletes = update.delete || [];
@@ -548,7 +537,7 @@ Datasets.prototype.batchFeatureUpdate = function(update, dataset, callback) {
     'update.delete must be an array of strings'
   );
 
-  this.client({
+  return this.client({
     path: constants.API_DATASET_FEATURES,
     params: {
       owner: this.owner,
@@ -557,5 +546,5 @@ Datasets.prototype.batchFeatureUpdate = function(update, dataset, callback) {
     method: 'post',
     entity: { put: inserts, delete: deletes },
     callback: callback
-  });
+  }).entity();
 };

--- a/lib/services/directions.js
+++ b/lib/services/directions.js
@@ -119,7 +119,7 @@ MapboxDirections.prototype.getDirections = function(waypoints, options, callback
       steps: steps
     },
     callback: callback
-  });
+  }).entity();
 };
 
 module.exports = MapboxDirections;

--- a/lib/services/directions.js
+++ b/lib/services/directions.js
@@ -67,12 +67,13 @@ MapboxDirections.prototype.getDirections = function(waypoints, options, callback
   if (callback === undefined && typeof options === 'function') {
     callback = options;
     options = {};
+  } else if (options === undefined) {
+    options = {};
   }
 
   // typecheck arguments
   invariant(Array.isArray(waypoints), 'waypoints must be an array');
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var encodedWaypoints = formatPoints(waypoints);
 
@@ -107,7 +108,7 @@ MapboxDirections.prototype.getDirections = function(waypoints, options, callback
     instructions = options.instructions;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_DIRECTIONS,
     params: {
       encodedWaypoints: encodedWaypoints,

--- a/lib/services/distance.js
+++ b/lib/services/distance.js
@@ -76,7 +76,7 @@ MapboxDistance.prototype.getDistances = function(waypoints, options, callback) {
     profile = options.profile;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_DISTANCE,
     params: {
       profile: profile
@@ -86,7 +86,7 @@ MapboxDistance.prototype.getDistances = function(waypoints, options, callback) {
     },
     method: 'post',
     callback: callback
-  });
+  }).entity();
 };
 
 module.exports = MapboxDistance;

--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -60,7 +60,6 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
   // typecheck arguments
   invariant(typeof query === 'string', 'query must be a string');
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var queryOptions = {
     query: query,
@@ -95,11 +94,11 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
     queryOptions.types = options.types;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_GEOCODING_FORWARD,
     params: queryOptions,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -139,7 +138,6 @@ MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback)
   // typecheck arguments
   invariant(typeof location === 'object', 'location must be an object');
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   invariant(typeof location.latitude === 'number' &&
     typeof location.longitude === 'number',
@@ -168,11 +166,11 @@ MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback)
   queryOptions.longitude = roundTo(location.longitude, precision);
   queryOptions.latitude = roundTo(location.latitude, precision);
 
-  this.client({
+  return this.client({
     path: constants.API_GEOCODING_REVERSE,
     params: queryOptions,
     callback: callback
-  });
+  }).entity();
 };
 
 module.exports = MapboxGeocoding;

--- a/lib/services/matching.js
+++ b/lib/services/matching.js
@@ -76,7 +76,6 @@ MapboxMatching.prototype.matching = function(trace, options, callback) {
   // typecheck arguments
   invariant(geojsonhint.hint(trace).length === 0, 'trace must be valid GeoJSON');
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var profile = 'mapbox.driving',
     gps_precision = 4,
@@ -98,7 +97,7 @@ MapboxMatching.prototype.matching = function(trace, options, callback) {
     geometry = options.geometry;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_MATCHING,
     params: {
       profile: profile,
@@ -108,7 +107,7 @@ MapboxMatching.prototype.matching = function(trace, options, callback) {
     method: 'post',
     entity: trace,
     callback: callback
-  });
+  }).entity();
 };
 
 module.exports = MapboxMatching;

--- a/lib/services/surface.js
+++ b/lib/services/surface.js
@@ -52,7 +52,6 @@ MapboxSurface.prototype.surface = function(mapid, layer, fields, path, options, 
   invariant(Array.isArray(fields), 'fields must be an array of strings');
   invariant(Array.isArray(path) || typeof path === 'string', 'path must be an array of objects or a string');
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var interpolate = true,
     geojson = false;
@@ -86,11 +85,11 @@ MapboxSurface.prototype.surface = function(mapid, layer, fields, path, options, 
     surfaceOptions.z = options.zoom;
   }
 
-  this.client({
+  return this.client({
     path: constants.API_SURFACE,
     params: surfaceOptions,
     callback: callback
-  });
+  }).entity();
 };
 
 module.exports = MapboxSurface;

--- a/lib/services/tilestats.js
+++ b/lib/services/tilestats.js
@@ -17,7 +17,6 @@ var Tilestats = module.exports = makeService('MapboxTilestats');
  */
 Tilestats.prototype.createTilestats = function(tileset, layers, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(Array.isArray(layers), 'layers must be an array');
   invariant(layers.every(function(layer) {
     return typeof layer === 'string';
@@ -26,7 +25,7 @@ Tilestats.prototype.createTilestats = function(tileset, layers, callback) {
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_STATISTICS,
     params: {
       owner: owner,
@@ -35,7 +34,7 @@ Tilestats.prototype.createTilestats = function(tileset, layers, callback) {
     entity: { layers: layers },
     method: 'post',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -48,12 +47,11 @@ Tilestats.prototype.createTilestats = function(tileset, layers, callback) {
  */
 Tilestats.prototype.deleteTilestats = function(tileset, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_STATISTICS,
     params: {
       owner: owner,
@@ -61,7 +59,7 @@ Tilestats.prototype.deleteTilestats = function(tileset, callback) {
     },
     method: 'delete',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -98,19 +96,18 @@ Tilestats.prototype.deleteTilestats = function(tileset, callback) {
  */
 Tilestats.prototype.getTilestats = function(tileset, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_STATISTICS,
     params: {
       owner: owner,
       tileset: tileset
     },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -135,14 +132,13 @@ Tilestats.prototype.getTilestats = function(tileset, callback) {
  */
 Tilestats.prototype.updateTilestatsLayer = function(tileset, layer, geometries, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(typeof layer === 'string', 'layer must be a string');
   invariant(typeof geometries === 'object', 'geometries must be an object');
 
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_LAYER,
     params: {
       owner: owner,
@@ -152,7 +148,7 @@ Tilestats.prototype.updateTilestatsLayer = function(tileset, layer, geometries, 
     entity: geometries,
     method: 'post',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -173,7 +169,6 @@ Tilestats.prototype.updateTilestatsLayer = function(tileset, layer, geometries, 
  */
 Tilestats.prototype.updateTilestatsAttribute = function(tileset, layer, attribute, stats, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(typeof layer === 'string', 'layer must be a string');
   invariant(typeof attribute === 'string', 'attribute must be a string');
   invariant(typeof stats === 'object', 'stats must be an object');
@@ -181,7 +176,7 @@ Tilestats.prototype.updateTilestatsAttribute = function(tileset, layer, attribut
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_ATTRIBUTE,
     params: {
       owner: owner,
@@ -192,7 +187,7 @@ Tilestats.prototype.updateTilestatsAttribute = function(tileset, layer, attribut
     entity: stats,
     method: 'post',
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -225,14 +220,13 @@ Tilestats.prototype.updateTilestatsAttribute = function(tileset, layer, attribut
  */
 Tilestats.prototype.getTilestatsAttribute = function(tileset, layer, attribute, callback) {
   invariant(typeof tileset === 'string', 'tileset must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
   invariant(typeof layer === 'string', 'layer must be a string');
   invariant(typeof attribute === 'string', 'attribute must be a string');
 
   var owner = tileset.split('.')[0];
   if (owner === tileset) owner = this.owner;
 
-  this.client({
+  return this.client({
     path: constants.API_TILESTATS_ATTRIBUTE,
     params: {
       owner: owner,
@@ -241,5 +235,5 @@ Tilestats.prototype.getTilestatsAttribute = function(tileset, layer, attribute, 
       attribute: attribute
     },
     callback: callback
-  });
+  }).entity();
 };

--- a/lib/services/uploads.js
+++ b/lib/services/uploads.js
@@ -42,13 +42,11 @@ var Uploads = module.exports = makeService('MapboxUploads');
  * });
  */
 Uploads.prototype.listUploads = function(callback) {
-  invariant(typeof callback === 'function', 'callback must be a function');
-
-  this.client({
+  return this.client({
     path: constants.API_UPLOADS,
     params: { owner: this.owner },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -90,13 +88,11 @@ Uploads.prototype.listUploads = function(callback) {
  * });
  */
 Uploads.prototype.createUploadCredentials = function(callback) {
-  invariant(typeof callback === 'function', 'callback must be a function');
-
-  this.client({
+  return this.client({
     path: constants.API_UPLOAD_CREDENTIALS,
     params: { owner: this.owner },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -143,14 +139,13 @@ Uploads.prototype.createUploadCredentials = function(callback) {
  */
 Uploads.prototype.createUpload = function(options, callback) {
   invariant(typeof options === 'object', 'options must be an object');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_UPLOADS,
     params: { owner: this.owner },
     entity: options,
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -179,16 +174,15 @@ Uploads.prototype.createUpload = function(options, callback) {
  */
 Uploads.prototype.readUpload = function(upload, callback) {
   invariant(typeof upload === 'string', 'upload must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     path: constants.API_UPLOAD,
     params: {
       owner: this.owner,
       upload: upload
     },
     callback: callback
-  });
+  }).entity();
 };
 
 /**
@@ -205,9 +199,8 @@ Uploads.prototype.readUpload = function(upload, callback) {
  */
 Uploads.prototype.deleteUpload = function(upload, callback) {
   invariant(typeof upload === 'string', 'upload must be a string');
-  invariant(typeof callback === 'function', 'callback must be a function');
 
-  this.client({
+  return this.client({
     method: 'delete',
     path: constants.API_UPLOAD,
     params: {
@@ -215,5 +208,5 @@ Uploads.prototype.deleteUpload = function(upload, callback) {
       upload: upload
     },
     callback: callback
-  });
+  }).entity();
 };

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -76,9 +76,6 @@ test('DatasetClient', function(datasetClient) {
     listDatasets.test('typecheck', function(assert) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created dataset client');
-      assert.throws(function() {
-        client.listDatasets();
-      }, 'no callback function');
       assert.end();
     });
 
@@ -108,9 +105,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.readDataset([], function() {});
       }, 'dataset must be a string');
-      assert.throws(function() {
-        client.readDataset('help');
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -149,9 +143,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.updateDataset('help', { ham: 'sandwich' }, function() {});
       }, 'must update name or description');
-      assert.throws(function() {
-        client.updateDataset('help', {name: 'needs' });
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -189,9 +180,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.insertFeature(validFeature, [], function() {});
       }, 'dataset must be a string');
-      assert.throws(function() {
-        client.insertFeature(validFeature, testDatasets[0]);
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -220,9 +208,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.readFeature('', [], function() {});
       }, 'dataset must be a string');
-      assert.throws(function() {
-        client.readFeature('', '');
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -258,9 +243,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.deleteFeature('', [], function() {});
       }, 'dataset must be a string');
-      assert.throws(function() {
-        client.deleteFeature('', '');
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -300,17 +282,11 @@ test('DatasetClient', function(datasetClient) {
         client.batchFeatureUpdate({}, {}, function() {});
       }, 'dataset must be a string');
       assert.throws(function() {
-        client.batchFeatureUpdate({}, '', '');
-      }, 'callback must be a function');
-      assert.throws(function() {
         client.batchFeatureUpdate({ put: validFeature }, '', function() {});
       }, 'update.put must be an array of valid GeoJSON');
       assert.throws(function() {
         client.batchFeatureUpdate({ delete: [validFeature] }, '', function() {});
       }, 'update.delete must be an array of strings');
-      assert.throws(function() {
-        client.batchFeatureUpdate([], [''], '');
-      }, 'callback must be a function');
       assert.throws(function() {
         client.batchFeatureUpdate([validFeature], [''], '', function() {});
       }, 'inserted features must include ids');
@@ -401,9 +377,6 @@ test('DatasetClient', function(datasetClient) {
         client.listFeatures([], '', function() {});
       }, 'options must be a object');
       assert.throws(function() {
-        client.listFeatures('');
-      }, 'callback must be a function');
-      assert.throws(function() {
         client.listFeatures([], {
           reverse: ''
         }, function() {});
@@ -482,9 +455,6 @@ test('DatasetClient', function(datasetClient) {
       assert.throws(function() {
         client.deleteDataset([], function() {});
       }, 'dataset must be a string');
-      assert.throws(function() {
-        client.deleteDataset('help');
-      }, 'callback must be a function');
       assert.end();
     });
 

--- a/test/directions.js
+++ b/test/directions.js
@@ -46,7 +46,7 @@ test('MapboxClient#getDirections', function(t) {
       { latitude: 33.6875431, longitude: -95.4431142 },
       { latitude: 33.6875431, longitude: -95.4831142 }
     ]).then(function(results) {
-      t.deepEqual(geojsonhint.hint(results.entity.origin), [], 'origin is valid');
+      t.deepEqual(geojsonhint.hint(results.origin), [], 'origin is valid');
       t.end();
     }, function(err) {
       t.ifError(err);
@@ -66,6 +66,7 @@ test('MapboxClient#getDirections', function(t) {
       t.notOk(params.alternatives, 'alternatives option is set to false');
       t.notOk(params.steps, 'steps option is set to false');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     client.getDirections.apply(tester, [[

--- a/test/directions.js
+++ b/test/directions.js
@@ -39,6 +39,20 @@ test('MapboxClient#getDirections', function(t) {
     });
   });
 
+  t.test('promise interface', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+    client.getDirections([
+      { latitude: 33.6875431, longitude: -95.4431142 },
+      { latitude: 33.6875431, longitude: -95.4831142 }
+    ]).then(function(results) {
+      t.deepEqual(geojsonhint.hint(results.entity.origin), [], 'origin is valid');
+      t.end();
+    }, function(err) {
+      t.ifError(err);
+    });
+  });
+
   t.test('assert options', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -47,6 +47,18 @@ test('MapboxClient#geocodeForward', function(t) {
     });
   });
 
+  t.test('dataset option', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+    client.geocodeForward(
+      'Chester, New Jersey', { dataset: 'mapbox.places' })
+    .then(function(results) {
+      t.deepEqual(geojsonhint.hint(results), [], 'results are valid');
+      t.equal(geojsonhint.hint(results.features[0]).length, 0, 'at least one valid result');
+      t.end();
+    });
+  });
+
   t.test('options.country', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
@@ -55,6 +67,7 @@ test('MapboxClient#geocodeForward', function(t) {
       var params = opts.params;
       t.equals(params.country, 'ca', 'country option is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     client.geocodeForward.apply(tester, ['Paris', {
@@ -73,6 +86,7 @@ test('MapboxClient#geocodeForward', function(t) {
       var params = opts.params;
       t.equals(params.types, 'country,region', 'types option is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     client.geocodeForward.apply(tester, ['Paris', {
@@ -104,6 +118,7 @@ test('MapboxClient#geocodeForward', function(t) {
       });
       t.ok(opts.params.proximity, 'proximity is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     t.ok(client);
@@ -124,6 +139,7 @@ test('MapboxClient#geocodeForward', function(t) {
       });
       t.ok(opts.params.proximity, 'proximity is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     t.ok(client);
@@ -176,6 +192,7 @@ test('MapboxClient#geocodeReverse', function(t) {
       var params = opts.params;
       t.equals(params.types, 'country,region', 'types option is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     client.geocodeReverse.apply(tester, [
@@ -210,6 +227,7 @@ test('MapboxClient#geocodeReverse', function(t) {
       t.ok(opts.params.longitude, 'longitude is set');
       t.ok(opts.params.latitude, 'latitude is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     t.ok(client);
@@ -232,6 +250,7 @@ test('MapboxClient#geocodeReverse', function(t) {
       t.ok(opts.params.longitude, 'longitude is set');
       t.ok(opts.params.latitude, 'latitude is set');
       opts.callback();
+      return { entity: function() {} };
     }};
 
     t.ok(client);

--- a/test/tilestats.js
+++ b/test/tilestats.js
@@ -16,9 +16,6 @@ test('TilestatsClient', function(tilestatsClient) {
         client.createTilestats(null, ['ham'], function() {});
       }, 'tileset must be a string');
       assert.throws(function() {
-        client.createTilestats('yes', ['ham']);
-      }, 'callback must be a function');
-      assert.throws(function() {
         client.createTilestats('yes', 'ham', function() {});
       }, 'layers must be an array');
       assert.throws(function() {
@@ -31,6 +28,27 @@ test('TilestatsClient', function(tilestatsClient) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       client.createTilestats(tilesetid, ['layer'], function(err, result) {
         assert.ifError(err, 'success');
+        assert.deepEqual(result, {
+          account: client.owner,
+          tilesetid: tilesetid,
+          layers: [
+            {
+              account: client.owner,
+              tilesetid: tilesetid,
+              layer: 'layer',
+              geometry: 'UNKNOWN',
+              count: 0,
+              attributes: []
+            }
+          ]
+        }, 'expected result');
+        assert.end();
+      });
+    });
+
+    createTilestats.test('creates - promise style', function(assert) {
+      var client = new MapboxClient(process.env.MapboxAccessToken);
+      client.createTilestats(tilesetid, ['layer']).then(function(result) {
         assert.deepEqual(result, {
           account: client.owner,
           tilesetid: tilesetid,
@@ -82,9 +100,6 @@ test('TilestatsClient', function(tilestatsClient) {
       assert.throws(function() {
         client.updateTilestatsLayer(null, 'ham', {}, function() {});
       }, 'tileset must be a string');
-      assert.throws(function() {
-        client.updateTilestatsLayer('yes', 'ham', {});
-      }, 'callback must be a function');
       assert.throws(function() {
         client.updateTilestatsLayer('yes', null, {}, function() {});
       }, 'layer must be a string');
@@ -139,9 +154,6 @@ test('TilestatsClient', function(tilestatsClient) {
       assert.throws(function() {
         client.updateTilestatsAttribute(null, 'ham', 'eggs', {}, function() {});
       }, 'tileset must be a string');
-      assert.throws(function() {
-        client.updateTilestatsAttribute('yes', 'ham', 'eggs', {});
-      }, 'callback must be a function');
       assert.throws(function() {
         client.updateTilestatsAttribute('yes', null, 'eggs', {}, function() {});
       }, 'layer must be a string');
@@ -204,9 +216,6 @@ test('TilestatsClient', function(tilestatsClient) {
         client.getTilestatsAttribute(null, 'ham', 'eggs', function() {});
       }, 'tileset must be a string');
       assert.throws(function() {
-        client.getTilestatsAttribute('yes', 'ham', 'eggs');
-      }, 'callback must be a function');
-      assert.throws(function() {
         client.getTilestatsAttribute('yes', null, 'eggs', function() {});
       }, 'layer must be a string');
       assert.throws(function() {
@@ -262,9 +271,6 @@ test('TilestatsClient', function(tilestatsClient) {
       assert.throws(function() {
         client.getTilestats(null, function() {});
       }, 'tileset must be a string');
-      assert.throws(function() {
-        client.getTilestats('yes');
-      }, 'callback must be a function');
       assert.end();
     });
 
@@ -337,9 +343,6 @@ test('TilestatsClient', function(tilestatsClient) {
       assert.throws(function() {
         client.deleteTilestats(null, function() {});
       }, 'tileset must be a string');
-      assert.throws(function() {
-        client.deleteTilestats('yes');
-      }, 'callback must be a function');
       assert.end();
     });
 

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -23,12 +23,6 @@ test('UploadClient', function(uploadClient) {
     createUploadCredentials.test('typecheck', function(assert) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created upload client');
-      assert.throws(function() {
-        client.createUploadCredentials(100, function() {});
-      }, 'throws owner must be a string error');
-      assert.throws(function() {
-        client.createUploadCredentials();
-      }, 'throw no callback function error');
       assert.end();
     });
 
@@ -72,9 +66,6 @@ test('UploadClient', function(uploadClient) {
       assert.throws(function() {
         client.createUpload('ham', function() {});
       }, 'throws option not an object error');
-      assert.throws(function() {
-        client.createUpload();
-      }, 'throws no callback function error');
       assert.end();
     });
 
@@ -121,25 +112,22 @@ test('UploadClient', function(uploadClient) {
       assert.throws(function() {
         client.readUpload(100, function() {});
       }, 'throws owner must be a string error');
-      assert.throws(function() {
-        client.readUpload();
-      }, 'throws no callback function error');
       assert.end();
     });
 
     readUpload.test('valid request', function(assert) {
+      assert.plan(2);
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created upload client');
       var upload = testUploads.shift();
       var attempts = 0;
       function poll() {
         client.readUpload(upload.id, function(err, upload) {
-          assert.ifError(err, 'success');
           if (attempts > 4) throw new Error('Upload did not complete in time');
           // we are waiting for mapbox to process the upload
           if (!upload.complete) return setTimeout(poll, Math.pow(2, attempts++) * 1000);
+          assert.ifError(err, 'success');
           completedUpload = upload;
-          assert.end();
         });
       }
       poll();
@@ -161,12 +149,6 @@ test('UploadClient', function(uploadClient) {
     listUploads.test('typecheck', function(assert) {
       var client = new MapboxClient(process.env.MapboxAccessToken);
       assert.ok(client, 'created upload client');
-      assert.throws(function() {
-        client.listUploads(100, function() {});
-      }, 'throws owner must be a string error');
-      assert.throws(function() {
-        client.listUploads();
-      }, 'throws no callback function error');
       assert.end();
     });
 
@@ -189,9 +171,6 @@ test('UploadClient', function(uploadClient) {
       assert.throws(function() {
         client.deleteUpload(100, function() {});
       }, 'throws owner must be a string error');
-      assert.throws(function() {
-        client.deleteUpload();
-      }, 'throws no callback function error');
       assert.end();
     });
 


### PR DESCRIPTION
cc @scothis does this seem like the right approach for promise support? should we expose the full request like this and expect consumers to grab the `entity` property?

* [x] datasets.js
* [x] directions.js
* [x] distance.js
* [x] geocoding.js
* [x] matching.js
* [x] static.js
* [x] surface.js
* [x] tilestats.js
* [x] uploads.js


Fixes #76 