### PR TITLE
testing node 4 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ node_js:
 - '4'
 env:
   global:
-    secure: ED+05KdMKREJdP8doskLsejnN0KnqES6o8g3juRwRWnwWoa6E+NJGv34ayxIf+2q/XI6ReWVwIkQkhlw4m/nLO06SPISGQtHkYBe1xHDqpM/BoB7XMxN/znFe+vB//AX8TTK1Pk7hC0BuSd2728fcsROHZCqxwiy723WPRnf2Gs=
+    secure: s5Gkl8zV18XJabPnvrxAsPLNG0S3NN9Jn8t+x9bkygnUJ+iZNsXoblHXDlikPMCwySIa6mOSCVWsuSQJvxJqJMV1QYwiMRE/ljkt7BP9+jAC4L/13yjAVHVhmiOd6dBX70rwKSJ2W5eGmpl5XO6aLqLaUjDUIZFMkZm8YhtfCow=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_script:
 sudo: false
 node_js:
 - '0.12'
+- '4'
 env:
   global:
     secure: ED+05KdMKREJdP8doskLsejnN0KnqES6o8g3juRwRWnwWoa6E+NJGv34ayxIf+2q/XI6ReWVwIkQkhlw4m/nLO06SPISGQtHkYBe1xHDqpM/BoB7XMxN/znFe+vB//AX8TTK1Pk7hC0BuSd2728fcsROHZCqxwiy723WPRnf2Gs=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ node_js:
 - '4'
 env:
   global:
-    secure: s5Gkl8zV18XJabPnvrxAsPLNG0S3NN9Jn8t+x9bkygnUJ+iZNsXoblHXDlikPMCwySIa6mOSCVWsuSQJvxJqJMV1QYwiMRE/ljkt7BP9+jAC4L/13yjAVHVhmiOd6dBX70rwKSJ2W5eGmpl5XO6aLqLaUjDUIZFMkZm8YhtfCow=
+    secure: UrfB0BI2DSCwbwYV3MucH8r03vnXpEMtSde5GdIWv8EpldScZEF/42eFwFVs1ts6DUbTmV+EeDeApIakAyV5aLP/nZmoOcyRM/7tRmgkHhX91KneDfU0oiR/KXAy3WMvYRzSnDLXXGx4a3T04uMyKhnYRyM8nvTnenjPpk7ghPI=


### PR DESCRIPTION
Adding node 4 to travis tests.

Looks like there are some unexpected issues with the token used in the tests for both `0.12` and `4`, which means this is technically failing on `master`. 

First error seems to be the culprit of the rest of subsequent errors:

```
This API requires a token with styles:list scope.
```