### PR TITLE
Install Promise polyfill before rest.js is loaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
 - sh -e /etc/init.d/xvfb start
 sudo: false
 node_js:
-- '0.12'
+- '0.10'
 - '4'
 env:
   global:

--- a/lib/callbackify.js
+++ b/lib/callbackify.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// install ES6 Promise polyfill
+require('../vendor/promise');
+
 var interceptor = require('rest/interceptor');
 
 var callbackify = interceptor({

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// install ES6 Promise polyfill
+require('../vendor/promise');
+
 var rest = require('rest');
 var callbackify = require('./callbackify');
 

--- a/lib/mapbox.js
+++ b/lib/mapbox.js
@@ -12,8 +12,6 @@ var MapboxDatasets = require('./services/datasets');
 var MapboxDistance = require('./services/distance');
 var MapboxTilestats = require('./services/tilestats');
 
-// install ES6 Promise polyfill
-require('../vendor/promise');
 
 /**
  * The JavaScript API to Mapbox services

--- a/lib/services/styles.js
+++ b/lib/services/styles.js
@@ -328,7 +328,7 @@ Styles.prototype.deleteIcon = function(styleid, iconName, callback) {
  * @param {string} style the id for an existing style
  * @param {Object} options
  * @param {boolean=false} options.title If true, shows a title box in upper right
- * corner with map title and owner 
+ * corner with map title and owner
  * @param {boolean=true} options.zoomwheel Disables zooming with mouse scroll wheel
  * @returns {string} URL of style embed page
  * @example


### PR DESCRIPTION
For environment that do not support Promises natively, there is a
Promise polyfill included with mapbox-sdk-js. This polyfill needs to be
loaded before rest.js is loaded.

Testing in node 0.10 instead of 0.12 since it doesn't include Promises by
default.