### PR TITLE
Change the param `auth_token` to `api_token`

### DIFF
--- a/lib/services/static.js
+++ b/lib/services/static.js
@@ -82,7 +82,7 @@ MapboxStatic.prototype.getStaticURL = function(mapid, width, height, position, o
     width: width,
     xyz: xyz,
     height: height,
-    access_token: this.accessToken
+    api_token: this.accessToken
   });
 
   if (params.retina === true) {


### PR DESCRIPTION
Template has the variable `api_token` instead of `auth_token`
`/v4/{mapid}{+overlay}/{+xyz}/{width}x{height}{+retina}{.format}{?api_token}`

Changed to `api_token` instead so it can render the correct url.