### PR TITLE
Add Geocoding `Limit` Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-beta4
+
+- Add `limit` option to geocoder API
+- Add `poi.landmark` type to geocoder API
+
 ## 1.0.0-beta3
 
 - Update tilestat service for new API.

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,7 +4,7 @@
 module.exports.DEFAULT_ENDPOINT = 'https://api.mapbox.com';
 
 module.exports.API_GEOCODING_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity,country,types,bbox,limit}';
-module.exports.API_GEOCODING_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json{?types}';
+module.exports.API_GEOCODING_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json{?types,limit}';
 
 module.exports.API_DIRECTIONS = '/v4/directions/{profile}/{encodedWaypoints}.json{?alternatives,instructions,geometry,steps}';
 module.exports.API_DISTANCE = '/distances/v1/mapbox/{profile}';

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,9 +1,9 @@
 // We keep all of the constants that declare endpoints in one
-// place, so that we could concievably update this for API layout
+// place, so that we could conceivably update this for API layout
 // revisions.
 module.exports.DEFAULT_ENDPOINT = 'https://api.mapbox.com';
 
-module.exports.API_GEOCODING_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity,country,types,bbox}';
+module.exports.API_GEOCODING_FORWARD = '/geocoding/v5/{dataset}/{query}.json{?proximity,country,types,bbox,limit}';
 module.exports.API_GEOCODING_REVERSE = '/geocoding/v5/{dataset}/{longitude},{latitude}.json{?types}';
 
 module.exports.API_DIRECTIONS = '/v4/directions/{profile}/{encodedWaypoints}.json{?alternatives,instructions,geometry,steps}';

--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -34,6 +34,8 @@ function roundTo(value, places) {
  * @param {string} options.types a comma seperated list of types that filter
  * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
  * for available types.
+ * @param {number=5} options.limit is the maximum number of results to return, in range 1 to 10.
+ * Some very specific queries may return fewer results than the limit.
  * @param {string} options.country a comma separated list of country codes to
  * limit results to specified country or countries.
  * @param {boolean=true} options.autocomplete whether to include results that include
@@ -110,6 +112,12 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
       options.bbox.length === 4,
       'bbox must be an array with numeric values in the form [minX, minY, maxX, maxY]');
     queryOptions.bbox = options.bbox[0] + "," + options.bbox[1] + "," + options.bbox[2] + "," + options.bbox[3];
+  }
+
+  if (options.limit) {
+    invariant(typeof options.limit === 'number',
+      'limit must be a number');
+    queryOptions.limit = options.limit;
   }
 
   if (options.dataset) {

--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -34,7 +34,7 @@ function roundTo(value, places) {
  * @param {string} options.types a comma seperated list of types that filter
  * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
  * for available types.
- * @param {number=5} options.limit is the maximum number of results to return, in range 1 to 10.
+ * @param {number=5} options.limit is the maximum number of results to return, between 1 and 10 inclusive.
  * Some very specific queries may return fewer results than the limit.
  * @param {string} options.country a comma separated list of country codes to
  * limit results to specified country or countries.

--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -149,7 +149,7 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
 
 /**
  * Given a location, determine what geographical features are located
- * there. This uses the [Mapbox Geocoding API](https://www.mapbox.com/developers/api/geocoding/).
+ * there. This uses the [Mapbox Geocoding API](https://www.mapbox.com/api-documentation/#geocoding).
  *
  * @param {Object} location the geographical point to search
  * @param {number} location.latitude decimal degrees latitude, in range -90 to 90
@@ -157,8 +157,11 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
  * @param {Object} [options={}] additional options meant to tune
  * the request.
  * @param {string} options.types a comma seperated list of types that filter
- * results to match those specified. See https://www.mapbox.com/developers/api/geocoding/#filter-type
+ * results to match those specified. See 
+ * https://www.mapbox.com/api-documentation/#retrieve-places-near-a-location
  * for available types.
+ * @param {number=1} options.limit is the maximum number of results to return, between 1 and 5
+ * inclusive. Requires a single options.types to be specified (see example).
  * @param {string} [options.dataset=mapbox.places] the desired data to be
  * geocoded against. The default, mapbox.places, does not permit unlimited
  * caching. `mapbox.places-permanent` is available on request and does
@@ -171,6 +174,13 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
  *   { latitude: 33.6875431, longitude: -95.4431142 },
  *   function(err, res) {
  *   // res is a GeoJSON document with geocoding matches
+ * });
+ * @example
+ * var mapboxClient = new MapboxGeocoding('ACCESSTOKEN');
+ * mapboxClient.geocodeReverse(
+ *   { latitude: 33.6875431, longitude: -95.4431142, options: { types: address, limit: 3 } },
+ *   function(err, res) {
+ *   // res is a GeoJSON document with up to 3 geocoding matches
  * });
  */
 MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback) {
@@ -207,6 +217,12 @@ MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback)
   if (options.types) {
     invariant(typeof options.types === 'string', 'types option must be string');
     queryOptions.types = options.types;
+  }
+
+  if (options.limit) {
+    invariant(typeof options.limit === 'number', 'limit option must be a number');
+    invariant(options.types.split(',').length === 1, 'a single type must be specified to use the limit option');
+    queryOptions.limit = options.limit;
   }
 
   queryOptions.longitude = roundTo(location.longitude, precision);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox",
-  "version": "1.0.0-beta3",
+  "version": "1.0.0-beta4",
   "description": "interface to mapbox services",
   "main": "lib/mapbox.js",
   "scripts": {

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -233,6 +233,25 @@ test('MapboxClient#geocodeForward', function(t) {
     }]);
   });
 
+  t.test('options.limit', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+
+    var tester = { client: function(opts) {
+      var params = opts.params;
+      t.equals(params.limit, 1, 'limit option is set');
+      opts.callback();
+      return { entity: function() {} };
+    }};
+
+    client.geocodeForward.apply(tester, ['Paris', {
+      limit: 1
+    }, function(err) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
   t.end();
 });
 

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -304,6 +304,27 @@ test('MapboxClient#geocodeReverse', function(t) {
     }]);
   });
 
+  t.test('options.limit', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+
+    var tester = { client: function(opts) {
+      var params = opts.params;
+      t.equals(params.limit, 2, 'limit option is set');
+      t.equals(params.types, 'poi', 'single types option is set');
+      opts.callback();
+      return { entity: function() {} };
+    }};
+
+    client.geocodeReverse.apply(tester, [
+    { latitude: 33.6875431, longitude: -95.4431142 },
+    { types: 'poi', limit: 2 },
+    function(err) {
+      t.ifError(err);
+      t.end();
+    }]);
+  });
+
   t.test('options.dataset', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -106,13 +106,13 @@ test('MapboxClient#geocodeForward', function(t) {
 
     var tester = { client: function(opts) {
       var params = opts.params;
-      t.equals(params.types, 'country,region', 'types option is set');
+      t.equals(params.types, 'country,region,poi.landmark', 'types option is set');
       opts.callback();
       return { entity: function() {} };
     }};
 
     client.geocodeForward.apply(tester, ['Paris', {
-      types: 'country,region'
+      types: 'country,region,poi.landmark'
     }, function(err) {
       t.ifError(err);
       t.end();


### PR DESCRIPTION
Adds the limit parameter for geocoding calls per https://github.com/mapbox/api-geocoder/issues/1102

Tests fail locally, but the same tests are failing on master. I based this on the PR for adding bbox; please let me know if anything is missing. 
