### PR TITLE
Cleanup CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: node_js
-script:
-- npm test
-- npm run browser-test-ff
-before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 sudo: false
-node_js:
-- '0.10'
-- '4'
 env:
   global:
     secure: UrfB0BI2DSCwbwYV3MucH8r03vnXpEMtSde5GdIWv8EpldScZEF/42eFwFVs1ts6DUbTmV+EeDeApIakAyV5aLP/nZmoOcyRM/7tRmgkHhX91KneDfU0oiR/KXAy3WMvYRzSnDLXXGx4a3T04uMyKhnYRyM8nvTnenjPpk7ghPI=
+matrix:
+  include:
+    - node_js: '4'
+      script: 'npm run lint'
+    - node_js: '0.10'
+      script: 'npm run unit-test'
+    - node_js: '4'
+      script: 'npm run unit-test'
+    - node_js: '4'
+      before_script:
+      - export DISPLAY=:99.0
+      - sh -e /etc/init.d/xvfb start
+      script: 'npm run browser-test-ff'

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "geojson-random": "^0.2.2",
     "geojsonhint": "^1.1.0",
     "smokestack": "^3.3.0",
-    "tap": "^1.3.1",
+    "tap": "^8.0.1",
     "tap-status": "^1.0.1",
     "tape": "^4.2.0",
     "uglifyjs": "^2.4.10"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "interface to mapbox services",
   "main": "lib/mapbox.js",
   "scripts": {
-    "test": "eslint lib test/*.js",
+    "test": "npm run lint && npm run unit-test",
+    "lint": "eslint lib test/*.js",
     "unit-test": "tap --coverage test/browser.js test/*.js",
     "browser-test": "browserify -t envify -t brfs test/*.js test/helpers/close.js | smokestack | tap-status",
     "browser-test-ff": "browserify -t envify -t brfs test/*.js test/helpers/close.js | smokestack -b firefox | tap-status",

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -97,7 +97,7 @@ test('UploadClient', function(uploadClient) {
       client.createUpload({
         tileset: 'blah'
       }, function(err /*, upload */) {
-        assert.equal(err.message, 'Missing property "url"');
+        assert.equal(err.message, 'Missing required property "url"');
         assert.end();
       });
     });


### PR DESCRIPTION
eslint will not run under Node 0.10, which is causing CI to fail. This
PR splits linting from running the test suite as separate jobs. There
are now four independent CI jobs:

1. lint
2. unit-test with Node 0.10
3. unit-test with Node 4
4. browser-test-ff

`npm test` now runs both the lint and the unit-test scripts.