### PR TITLE
Allow uploads more time to process

### DIFF
--- a/test/uploads.js
+++ b/test/uploads.js
@@ -123,7 +123,7 @@ test('UploadClient', function(uploadClient) {
       var attempts = 0;
       function poll() {
         client.readUpload(upload.id, function(err, upload) {
-          if (attempts > 4) throw new Error('Upload did not complete in time');
+          if (attempts > 5) throw new Error('Upload did not complete in time');
           // we are waiting for mapbox to process the upload
           if (!upload.complete) return setTimeout(poll, Math.pow(2, attempts++) * 1000);
           assert.ifError(err, 'success');
@@ -131,7 +131,7 @@ test('UploadClient', function(uploadClient) {
         });
       }
       poll();
-    }, { timeout: 10000 });
+    }, { timeout: 20000 });
 
     readUpload.test('does not exist', function(assert) {
       var client = new MapboxClient(process.env.MapboxAccessToken);


### PR DESCRIPTION
CI failures are too common because uploads take longer than 10 seconds
to process.