### PR TITLE
remove null distance test due to deprecation

### DIFF
--- a/test/distance.js
+++ b/test/distance.js
@@ -61,25 +61,5 @@ test('MapboxClient#getDistances', function(t) {
     });
   });
 
-  t.test('a null route', function(t) {
-    var client = new MapboxClient(process.env.MapboxAccessToken);
-    t.ok(client);
-    client.getDistances([
-      [-95.4431142, 33.6875431],
-      [-95.4831142, 33.6875431],
-      [-95.4831142, 33.2875431],
-      [0, 0],
-      [-95.4831142, 33.0875431]
-    ], {
-      profile: 'walking'
-    }, function(err, results) {
-      t.ifError(err);
-      t.ok(Array.isArray(results.durations), 'returns an array');
-      t.equal(results.durations.length, 5, 'array has correct dimension');
-      t.equal(results.durations[0].length, 5, 'array has correct dimension');
-      t.end();
-    });
-  });
-
   t.end();
 });


### PR DESCRIPTION
this is no longer supported by the distances API. removing this test should fix the build

cc @mapsam 