### PR TITLE
Avoid double URL encoding of geojson markers

### DIFF
--- a/lib/encode_overlay.js
+++ b/lib/encode_overlay.js
@@ -51,7 +51,7 @@ module.exports.encodePath = encodePath;
  * @private
  */
 function encodeGeoJSON(geojson) {
-  var encoded = encodeURIComponent(JSON.stringify(geojson));
+  var encoded = JSON.stringify(geojson);
   invariant(encoded.length < 4096, 'encoded GeoJSON must be shorter than 4096 characters long');
   return 'geojson(' + encoded + ')';
 }

--- a/test/encode_overlay.js
+++ b/test/encode_overlay.js
@@ -8,7 +8,7 @@ test('encodeGeoJSON', function(t) {
   t.equal(encodeOverlay.encodeGeoJSON({
     type: 'Point',
     coordinates: [0, 0]
-  }), 'geojson(%7B%22type%22%3A%22Point%22%2C%22coordinates%22%3A%5B0%2C0%5D%7D)');
+  }), 'geojson({"type":"Point","coordinates":[0,0]})');
   t.end();
 });
 

--- a/test/static.js
+++ b/test/static.js
@@ -47,7 +47,7 @@ test('MapboxStatic', function(t) {
   }, {
     retina: true,
     geojson: { type: 'Point', coordinates: [0, 0] }
-  })), 'https://api.mapbox.com/v4/foo/geojson(%257B%2522type%2522%253A%2522Point%2522%252C%2522coordinates%2522%253A%255B0%252C0%255D%257D)/1,2,3/10x10@2x.png', 'with geojson');
+  })), 'https://api.mapbox.com/v4/foo/geojson(%7B%22type%22:%22Point%22,%22coordinates%22:[0,0]%7D)/1,2,3/10x10@2x.png', 'with geojson');
 
   t.equal(removeToken(client.getStaticURL('foo', 10, 10, {
     longitude: 1, latitude: 2, zoom: 3


### PR DESCRIPTION
The previous geojson overlay was URL encoded internally and the value
was then url encoded again when it was placed into the URL. The value
should only be URL encoded when being placed into the URL.

This change also move the responsibility for the slash into the URI
template.

Issue: #154