### PR TITLE
Remove start and reverse opts for datasets listings

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -17,9 +17,9 @@ module.exports.API_UPLOAD_CREDENTIALS = '/uploads/v1/{owner}/credentials';
 
 module.exports.API_MATCHING = '/matching/v5/{account}/{profile}/{coordinates}.json{?geometries,radiuses,steps,overview,timestamps,annotations}';
 
-module.exports.API_DATASET_DATASETS = '/datasets/v1/{owner}{?limit,start,fresh}';
+module.exports.API_DATASET_DATASETS = '/datasets/v1/{owner}{?limit,fresh}';
 module.exports.API_DATASET_DATASET = '/datasets/v1/{owner}/{dataset}';
-module.exports.API_DATASET_FEATURES = '/datasets/v1/{owner}/{dataset}/features{?reverse,limit,start}';
+module.exports.API_DATASET_FEATURES = '/datasets/v1/{owner}/{dataset}/features{?limit}';
 module.exports.API_DATASET_FEATURE = '/datasets/v1/{owner}/{dataset}/features/{id}';
 
 module.exports.API_TILESTATS_STATISTICS = '/tilestats/v1/{owner}/{tileset}';

--- a/lib/services/datasets.js
+++ b/lib/services/datasets.js
@@ -12,7 +12,6 @@ var Datasets = module.exports = makeService('MapboxDatasets');
  * This request requires an access token with the datasets:read scope.
  *
  * @param {Object} [opts={}] list options
- * @param {string} opts.start start location, for paging
  * @param {number} opts.limit limit, for paging
  * @param {boolean} opts.fresh whether to request fresh data
  * @param {Function} callback called with (err, datasets)
@@ -51,7 +50,6 @@ Datasets.prototype.listDatasets = function(opts, callback) {
     path: constants.API_DATASET_DATASETS,
     params: {
       limit: opts.limit,
-      start: opts.start,
       fresh: opts.fresh,
       owner: this.owner
     },
@@ -214,9 +212,7 @@ Datasets.prototype.deleteDataset = function(dataset, callback) {
  *
  * @param {string} dataset the id for an existing dataset
  * @param {object} [options] an object for passing pagination arguments
- * @param {boolean} [options.reverse] Set to `true` to reverse the default sort order of the listing.
  * @param {number} [options.limit] The maximum number of objects to return. This value must be between 1 and 100. The API will attempt to return the requested number of objects, but receiving fewer objects does not necessarily signal the end of the collection. Receiving an empty page of results is the only way to determine when you are at the end of a collection.
- * @param {string} [options.start] The object id that acts as the cursor for pagination and defines your location in the collection. This argument is exclusive so the object associated with the id provided to the start argument will not be included in the response.
  * @param {Function} callback called with (err, collection)
  * @returns {Promise} response
  * @example
@@ -258,19 +254,9 @@ Datasets.prototype.listFeatures = function(dataset, options, callback) {
     dataset: dataset
   };
 
-  if (options.reverse) {
-    invariant(typeof options.reverse === 'boolean', 'reverse option must be a boolean');
-    params.reverse = options.reverse;
-  }
-
   if (options.limit) {
     invariant(typeof options.limit === 'number', 'limit option must be a number');
     params.limit = options.limit;
-  }
-
-  if (options.start) {
-    invariant(typeof options.start === 'string', 'start option must be a string');
-    params.start = options.start;
   }
 
   return this.client({
@@ -443,4 +429,3 @@ Datasets.prototype.deleteFeature = function(id, dataset, callback) {
     method: 'delete',
     callback: callback
   })};
-

--- a/test/datasets.js
+++ b/test/datasets.js
@@ -297,19 +297,9 @@ test('DatasetClient', function(datasetClient) {
       }, 'options must be a object');
       assert.throws(function() {
         client.listFeatures([], {
-          reverse: ''
-        }, function() {});
-      }, 'reverse option must be a boolean');
-      assert.throws(function() {
-        client.listFeatures([], {
           limit: ''
         }, function() {});
       }, 'limit option must be a number');
-      assert.throws(function() {
-        client.listFeatures([], {
-          start: true
-        }, function() {});
-      }, 'start option must be a string');
       assert.end();
     });
 
@@ -332,34 +322,6 @@ test('DatasetClient', function(datasetClient) {
       }, function(err, collection) {
         assert.ifError(err, 'success');
         assert.equal(collection.features.length, 1, 'returned one feature');
-        assert.end();
-      });
-    });
-
-    listFeatures.test('options.start', function(assert) {
-      var client = new MapboxClient(process.env.MapboxAccessToken);
-      assert.ok(client, 'created dataset client');
-      client.listFeatures(testDatasets[1], {
-        start: 'feature-1'
-      }, function(err, collection) {
-        assert.ifError(err, 'success');
-        assert.equal(collection.features.length, 1, 'returned one feature');
-        assert.end();
-      });
-    });
-
-    listFeatures.test('options.reverse', function(assert) {
-      var client = new MapboxClient(process.env.MapboxAccessToken);
-      assert.ok(client, 'created dataset client');
-      client.listFeatures(testDatasets[1], {
-        reverse: true
-      }, function(err, collection) {
-        assert.ifError(err, 'success');
-        var ids = collection.features.reduce(function(memo, feature) {
-          memo.push(feature.id);
-          return memo;
-        }, []);
-        assert.deepEqual(ids, ['feature-0', 'feature-1', 'feature-2'], 'features received in reverse order');
         assert.end();
       });
     });


### PR DESCRIPTION
The `start` parameter is an implementation detail of pagination and does
not need to be exposed to users. Use the `response.nextPage()` method
to paginate through results.

The `reverse` parameter is not implemented server side.