### PR TITLE
Add dependencies used in Paginator

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
   },
   "dependencies": {
     "es6-promise": "^4.0.5",
-    "rest": "^2.0.0"
+    "querystring": "^0.2.0",
+    "rest": "^2.0.0",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
The paginator.js file has dependencies to "querystring" and "url" that are not resolved in the package.json file.  This caused a problem for me in a new project where the url library hadn't already been included by another package.