### PR TITLE
Update README to show React Native install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Generally Available
 $ npm install --save mapbox
 ```
 
+## React Native Installation
+
+React Native does not ship with the url module so we have to polyfill it.
+
+```sh
+npm install --save url
+npm install --save mapbox
+```
+
 ## Usage
 
 Setup:


### PR DESCRIPTION
Currently this module does not work out of the box with react-native due to it's use of the url module. The standard node modules do not ship with react-native so if we polyfill the url module it does work. Figured we should just add a note about that incase anyone wants to also use this on RN.