### PR TITLE
Fix #164: Allow query to be the only arg specified

### DIFF
--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -70,9 +70,8 @@ function roundTo(value, places) {
  * });
  */
 MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
-
-  // permit the options argument to be omitted
-  if (callback === undefined && typeof options === 'function') {
+  // permit the options argument to be omitted, or the options + callback args to be omitted if using promise syntax
+  if (callback === undefined && (options === undefined || typeof options === 'function')) {
     callback = options;
     options = {};
   }
@@ -192,9 +191,8 @@ MapboxGeocoding.prototype.geocodeForward = function(query, options, callback) {
  * });
  */
 MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback) {
-
-  // permit the options argument to be omitted
-  if (callback === undefined && typeof options === 'function') {
+  // permit the options argument to be omitted, or the options + callback args to be omitted if using promise syntax
+  if (callback === undefined && (options === undefined || typeof options === 'function')) {
     callback = options;
     options = {};
   }

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -9,6 +9,9 @@ test('MapboxClient#geocodeForward', function(t) {
   t.test('typecheck', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
+    t.doesNotThrow(function () {
+      client.geocodeForward('foo');
+    });
     t.throws(function() {
       client.geocodeForward(null);
     }, /query/);
@@ -279,6 +282,9 @@ test('MapboxClient#geocodeReverse', function(t) {
   t.test('typecheck', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
+    t.doesNotThrow(function () {
+      client.geocodeReverse('foo');
+    });
     t.throws(function() {
       client.geocodeReverse(null);
     }, /options/, 'null string');


### PR DESCRIPTION
The docs indicate that `options` is an optional parameter. At the moment, that's true if you're using the callback syntax, however if you're using it as a promise (and therefore only have one argument specified, `query` as a string), it throws an error.

Instead, we should allow options to be either a function or undefined. If `callback` and `options` are both undefined, I've left the existing code to work as is, so `callback` to `options` (undefined to undefined) and default options to an empty object. The alternative was to have multiple or nested if statements.

Unit tests may need to be updated - I had trouble running them (likely as I only had a read-only token at the time)