### PR TITLE
fix tests for geocoding promise syntax from #197

### DIFF
--- a/lib/services/geocoding.js
+++ b/lib/services/geocoding.js
@@ -198,7 +198,7 @@ MapboxGeocoding.prototype.geocodeReverse = function(location, options, callback)
   }
 
   // typecheck arguments
-  invariant(typeof location === 'object', 'location must be an object');
+  invariant((typeof location === 'object' && location !== null), 'location must be an object');
   invariant(typeof options === 'object', 'options must be an object');
 
   invariant(typeof location.latitude === 'number' &&

--- a/test/geocoding.js
+++ b/test/geocoding.js
@@ -9,9 +9,6 @@ test('MapboxClient#geocodeForward', function(t) {
   t.test('typecheck', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
-    t.doesNotThrow(function () {
-      client.geocodeForward('foo');
-    });
     t.throws(function() {
       client.geocodeForward(null);
     }, /query/);
@@ -24,6 +21,15 @@ test('MapboxClient#geocodeForward', function(t) {
     t.throws(function() {
       client.geocodeForward('foo', 1);
     }, /options/);
+    t.end();
+  });
+
+  t.test('promise syntax', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+    t.doesNotThrow(function () {
+      client.geocodeForward('foo');
+    }, 'no callback');
     t.end();
   });
 
@@ -282,12 +288,9 @@ test('MapboxClient#geocodeReverse', function(t) {
   t.test('typecheck', function(t) {
     var client = new MapboxClient(process.env.MapboxAccessToken);
     t.ok(client);
-    t.doesNotThrow(function () {
-      client.geocodeReverse('foo');
-    });
     t.throws(function() {
       client.geocodeReverse(null);
-    }, /options/, 'null string');
+    }, /location/, 'null');
     t.throws(function() {
       client.geocodeReverse(1, function() {});
     }, /location/, 'number');
@@ -297,6 +300,15 @@ test('MapboxClient#geocodeReverse', function(t) {
     t.throws(function() {
       client.geocodeReverse('foo', 1);
     }, /location/, 'bad options 2');
+    t.end();
+  });
+
+  t.test('promise syntax', function(t) {
+    var client = new MapboxClient(process.env.MapboxAccessToken);
+    t.ok(client);
+    t.doesNotThrow(function () {
+      client.geocodeReverse({ latitude: 33.6875431, longitude: -95.4431142 });
+    }, 'no callback');
     t.end();
   });
 


### PR DESCRIPTION
There was an error in #197 which broke the unit tests. I didn't pick it up because the tests can only pass successfully in the Mapbox repo since they use a secret Mapbox token. :thinking: 