### PR TITLE
Requires an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ client.geocodeForward('Chester, NJ', function(err, data, res) {
 As an alternative to callbacks, each method also returns a Promise:
 
 ```js
-client.geocodeForward('Chester, NJ')
+client.geocodeForward('Chester, NJ', {})
   .then(function(res) {
     // res is the http response, including: status, headers and entity properties
     var data = res.entity; // data is the geocoding result as parsed JSON


### PR DESCRIPTION
Due to this line `invariant(typeof options === 'object', 'options must be an object');` https://github.com/mapbox/mapbox-sdk-js/blob/b68ef79af3123a89f4a6bbf3623c8777872a6508/lib/services/geocoding.js#L202 this seems to require an object otherwise you get an "Invariant Violation: options must be an object" error. An empty object will do.