### PR TITLE
v1.0.0-beta10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 1.0.0-beta9 
+## 1.0.0-beta10
+
+- **Bug** Fix bug preventing Geocoding service being used without an `options` parameter when using promise syntax. [#197](https://github.com/mapbox/mapbox-sdk-js/pull/197)
+- **Feature** Geocoding `language`, `country` and `types` parameters can be passed as arrays as an alternative to comma separated strings. [#208](https://github.com/mapbox/mapbox-sdk-js/pull/208)
+
+## 1.0.0-beta9
 
 - **Feature** Add language parameter to geocoding API. [#174](https://github.com/mapbox/mapbox-sdk-js/issues/174)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,13 @@ Run the tests
 ```sh
 $ npm test
 ```
+
+## Releasing
+
+- `npm run prepublish && npm run docs`
+- Update the version key in [package.json](https://github.com/mapbox/mapbox-sdk-js/blob/master/package.json#L3)
+- Outline changes in [CHANGELOG.md](https://github.com/mapbox/mapbox-sdk-js/blob/master/CHANGELOG.md)
+- Commit and push
+- `git tag -a vX.X.X -m 'vX.X.X'`
+- `git push --tags`
+- `npm publish`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "description": "interface to mapbox services",
   "main": "lib/mapbox.js",
   "scripts": {


### PR DESCRIPTION
We should do a new release to include #197. This may resolve #205.

after merged the tag will need to be added and someone with permissions publish to npm:

- `git tag -a vX.X.X -m 'vX.X.X'`
- `git push --tags`
- `npm publish`

I've also included some releasing instructions.

I hope #186 can be addressed too so breaking changes and patch releases are possible.