### PR TITLE
[REVITALIZATION] Fix error on multiple simultaneous requests; clarify docs

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -101,6 +101,10 @@ The `emitter` property is an `EventEmitter` that emits the following events:
     received an error in response, the error is available on this property.
 - `aborted` **[boolean][15]** If the request has been aborted
     (via [`abort`][8]), this property will be `true`.
+- `sent` **[boolean][15]** If the request has been sent, this property will
+    be `true`. You cannot send the same request twice, so if you need to create
+    a new request that is the equivalent of an existing one, use
+    [`clone`][10].
 - `path` **[string][11]** The request's path, including colon-prefixed route
     paratemers.
 - `origin` **[string][11]** The request's origin.
@@ -139,6 +143,9 @@ that might be aborted, you need to catch and handle such errors.
 
 This method will also abort any requests created while fetching subsequent
 pages via [`eachPage`][9].
+
+If the request has not been sent or has already been aborted, nothing
+will happen.
 
 ### eachPage
 

--- a/lib/classes/mapi-request.js
+++ b/lib/classes/mapi-request.js
@@ -29,6 +29,10 @@ var requestId = 1;
  *   received an error in response, the error is available on this property.
  * @property {boolean} aborted - If the request has been aborted
  *   (via [`abort`](#abort)), this property will be `true`.
+ * @property {boolean} sent - If the request has been sent, this property will
+ *   be `true`. You cannot send the same request twice, so if you need to create
+ *   a new request that is the equivalent of an existing one, use
+ *   [`clone`](#clone).
  * @property {string} path - The request's path, including colon-prefixed route
  *   paratemers.
  * @property {string} origin - The request's origin.
@@ -86,6 +90,7 @@ function MapiRequest(client, options) {
   this.client = client;
   this.response = null;
   this.error = null;
+  this.sent = false;
   this.aborted = false;
   this.path = options.path;
   this.method = options.method;
@@ -126,11 +131,12 @@ MapiRequest.prototype.url = function url(accessToken) {
 MapiRequest.prototype.send = function send() {
   var self = this;
 
-  if (self.response || self.error) {
+  if (self.sent) {
     throw new Error(
       'This request has already been sent. Check the response and error properties. Create a new request with clone().'
     );
   }
+  self.sent = true;
 
   return self.client.sendRequest(self).then(
     function(response) {
@@ -155,6 +161,9 @@ MapiRequest.prototype.send = function send() {
  *
  * This method will also abort any requests created while fetching subsequent
  * pages via [`eachPage`](#eachpage).
+ *
+ * If the request has not been sent or has already been aborted, nothing
+ * will happen.
  */
 MapiRequest.prototype.abort = function abort() {
   if (this._nextPageRequest) {

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -534,6 +534,13 @@ function testSharedInterface(createClient) {
       });
     });
 
+    test('request cannot be sent multiple times at once', () => {
+      expect(() => {
+        request.send();
+        request.send();
+      }).toThrow('has already been sent');
+    });
+
     test('should not error if you abort after the response is received', () => {
       return request.send().then(() => {
         expect(() => {


### PR DESCRIPTION
@kepta: This address your comment here: https://github.com/mapbox/mapbox-sdk-js/pull/217#issuecomment-388317162

It was already behaving as expected if you re-sent after a response or error were received (and this was tested). It was *not* behaving the same way if you sent multiple times right away. That was a bug, so I fixed it, added a test, and then added some clarifying docs.

> How does .eachPage signal done?

This is like `forEach`: the callback just doesn't run if there's not another page to run it on. Does that make sense? Is there something you think we need to say to clarify this?