### PR TITLE
Remove status code from MapiError message

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -73,8 +73,7 @@ method should reject with a `MapiError`.
     the HTTP response.
 - `body` **([Object][12] \| [string][11])?** If the server sent a response body,
     this property exposes that response, parsed as JSON if possible.
-- `message` **[string][11]?** A summary of the error, including the
-    status code and whatever message could be derived from the
+- `message` **[string][11]?** Whatever message could be derived from the
     call site and HTTP response.
 
 ## MapiRequest

--- a/lib/classes/__tests__/mapi-error.test.js
+++ b/lib/classes/__tests__/mapi-error.test.js
@@ -14,7 +14,7 @@ test('HTTP error with body that includes a message, and no options.message', () 
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(401);
   expect(error.body).toEqual({ message: 'You cannot see this' });
-  expect(error.message).toBe('401: You cannot see this');
+  expect(error.message).toBe('You cannot see this');
   expect(error.request).toBe(mockRequest);
 });
 
@@ -28,7 +28,7 @@ test('HTTP error with body that includes a message, but options.message override
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(401);
   expect(error.body).toEqual({ message: 'You cannot see this' });
-  expect(error.message).toBe('401: This is important');
+  expect(error.message).toBe('This is important');
   expect(error.request).toBe(mockRequest);
 });
 
@@ -54,7 +54,7 @@ test('HTTP error with body that is a string', () => {
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(477);
   expect(error.body).toBe('Hello');
-  expect(error.message).toBe('477: Hello');
+  expect(error.message).toBe('Hello');
   expect(error.request).toBe(mockRequest);
 });
 
@@ -67,7 +67,7 @@ test('HTTP error with body that cannot be parsed as JSON', () => {
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(477);
   expect(error.body).toBe('{Hello}');
-  expect(error.message).toBe('477: {Hello}');
+  expect(error.message).toBe('{Hello}');
   expect(error.request).toBe(mockRequest);
 });
 
@@ -81,7 +81,7 @@ test('HTTP error with body that does not include a message, but options.message 
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(477);
   expect(error.body).toEqual({ foo: 'bar' });
-  expect(error.message).toBe('477: This is important');
+  expect(error.message).toBe('This is important');
   expect(error.request).toBe(mockRequest);
 });
 
@@ -106,7 +106,7 @@ test('HTTP error with options.message but no body', () => {
   expect(error.type).toBe(constants.ERROR_HTTP);
   expect(error.statusCode).toBe(500);
   expect(error.body).toBeNull();
-  expect(error.message).toBe('500: Oops');
+  expect(error.message).toBe('Oops');
   expect(error.request).toBe(mockRequest);
 });
 

--- a/lib/classes/mapi-error.js
+++ b/lib/classes/mapi-error.js
@@ -20,8 +20,7 @@ var constants = require('../constants');
  *   the HTTP response.
  * @property {Object | string} [body] - If the server sent a response body,
  *   this property exposes that response, parsed as JSON if possible.
- * @property {string} [message] - A summary of the error, including the
- *   status code and whatever message could be derived from the
+ * @property {string} [message] - Whatever message could be derived from the
  *   call site and HTTP response.
  *
  * @param {MapiRequest} options.request
@@ -53,10 +52,6 @@ function MapiError(options) {
     } else if (errorType === constants.ERROR_REQUEST_ABORTED) {
       message = 'Request aborted';
     }
-  }
-
-  if (options.statusCode && message) {
-    message = options.statusCode + ': ' + message;
   }
 
   this.message = message;

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -610,7 +610,7 @@ function testSharedInterface(createClient) {
 
     test(`error.message combines status code and the error's message property`, () => {
       return expectRejection(request.send(), error => {
-        expect(error.message).toBe('404: Style not found');
+        expect(error.message).toBe('Style not found');
       });
     });
 


### PR DESCRIPTION
This was a mistake. Users can get the status code from the `statusCode` property.

cc @kepta 