### PR TITLE
Add Style#getStyleSprite, getFontGlyphRange, getEmbeddableHtml

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -250,7 +250,7 @@ See [the public documentation][38].
 **Parameters**
 
 - `config` **[Object][21]** 
-  - `config.fonts` **[Array][25]&lt;[string][22]>** An array of font names.
+  - `config.fonts` **([string][22] \| [Array][25]&lt;[string][22]>)** An array of font names.
   - `config.start` **[number][32]** Character code of the starting glyph.
   - `config.end` **[number][32]** Character code of the last glyph,
       typically equivalent to`config.start + 255`.

--- a/docs/services.md
+++ b/docs/services.md
@@ -4,6 +4,12 @@
 
 - [Tilesets](#tilesets)
   - [listTilesets](#listtilesets)
+- [Tokens](#tokens)
+  - [listTokens](#listtokens)
+  - [createToken](#createtoken)
+  - [updateToken](#updatetoken)
+  - [deleteToken](#deletetoken)
+  - [listScopes](#listscopes)
 - [Styles](#styles)
   - [getStyle](#getstyle)
   - [createStyle](#createstyle)
@@ -12,13 +18,9 @@
   - [listStyles](#liststyles)
   - [createStyleIcon](#createstyleicon)
   - [deleteStyleIcon](#deletestyleicon)
-  - [getStyleSpriteJson](#getstylespritejson)
-- [Tokens](#tokens)
-  - [listTokens](#listtokens)
-  - [createToken](#createtoken)
-  - [updateToken](#updatetoken)
-  - [deleteToken](#deletetoken)
-  - [listScopes](#listscopes)
+  - [getStyleSprite](#getstylesprite)
+  - [getFontGlyphRange](#getfontglyphrange)
+  - [getEmbeddableHtml](#getembeddablehtml)
 
 ## Tilesets
 
@@ -28,127 +30,12 @@ Tilesets API service.
 
 List a user's tilesets.
 
-See the [public documentation][18].
+See the [public documentation][20].
 
 **Parameters**
 
-- `config` **[Object][19]?** 
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-## Styles
-
-Styles API service.
-
-### getStyle
-
-Get a style.
-
-See the [public documentation][21].
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### createStyle
-
-Create a style.
-
-See the [public documentation][22].
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.style` **[Object][19]** Stylesheet JSON object.
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### updateStyle
-
-Update a style.
-
-See the [public documentation][23].
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.style` **[Object][19]** Stylesheet JSON object.
-  - `config.lastKnownModification` **([string][20] \| [number][24] \| [Date][25])?** Datetime of last
-      known update. Passed as 'If-Unmodified-Since' HTTP header.
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### deleteStyle
-
-Delete a style.
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### listStyles
-
-List styles in your account.
-
-**Parameters**
-
-- `config` **[Object][19]?** 
-  - `config.start` **[string][20]?** The style ID of the last style in the
-      previous page.
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### createStyleIcon
-
-Add an icon to a style.
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.iconId` **[string][20]** 
-  - `config.file` **([Blob][26] \| [ArrayBuffer][27] \| [string][20] | ReadableStream)** An SVG file.
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### deleteStyleIcon
-
-Remove an icon from a style.
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.iconId` **[string][20]** 
-  - `config.ownerId` **[string][20]?** 
-
-Returns **MapiRequest** 
-
-### getStyleSpriteJson
-
-Get a style's spritesheet in the JSON format.
-
-**Parameters**
-
-- `config` **[Object][19]** 
-  - `config.styleId` **[string][20]** 
-  - `config.highRes` **[boolean][28]?** If true, returns spritesheet with 2x
-      resolution.
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]?** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
 
@@ -160,12 +47,12 @@ Tokens API service.
 
 List a user's access tokens.
 
-See the [public documentation][29].
+See the [public documentation][23].
 
 **Parameters**
 
-- `config` **[Object][19]?** 
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]?** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
 
@@ -173,18 +60,18 @@ Returns **MapiRequest**
 
 Create a new access token.
 
-See the [public documentation][30].
+See the [public documentation][24].
 
 `resources` are only available for users with the `token_resources`
 feature flag.
 
 **Parameters**
 
-- `config` **[Object][19]?** 
-  - `config.note` **[string][20]?** 
-  - `config.scopes` **[Array][31]&lt;[string][20]>?** 
-  - `config.resources` **[Array][31]&lt;[string][20]>?** 
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]?** 
+  - `config.note` **[string][22]?** 
+  - `config.scopes` **[Array][25]&lt;[string][22]>?** 
+  - `config.resources` **[Array][25]&lt;[string][22]>?** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
 
@@ -192,19 +79,19 @@ Returns **MapiRequest**
 
 Update an access token.
 
-See the [public documentation][32].
+See the [public documentation][26].
 
 `resources` are only available for users with the `token_resources`
 feature flag.
 
 **Parameters**
 
-- `config` **[Object][19]** 
-  - `config.tokenId` **[string][20]** 
-  - `config.note` **[string][20]?** 
-  - `config.scopes` **[Array][31]&lt;[string][20]>?** 
-  - `config.resources` **[Array][31]&lt;[string][20]>?** 
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]** 
+  - `config.tokenId` **[string][22]** 
+  - `config.note` **[string][22]?** 
+  - `config.scopes` **[Array][25]&lt;[string][22]>?** 
+  - `config.resources` **[Array][25]&lt;[string][22]>?** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
 
@@ -212,13 +99,13 @@ Returns **MapiRequest**
 
 Delete an access token.
 
-See the [public documentation][33].
+See the [public documentation][27].
 
 **Parameters**
 
-- `config` **[Object][19]** 
-  - `config.tokenId` **[string][20]** 
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]** 
+  - `config.tokenId` **[string][22]** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
 
@@ -227,79 +114,240 @@ Returns **MapiRequest**
 List a user's available scopes. Each item is a metadata
 object about the scope, not just the string scope.
 
-See the [public documentation][34].
+See the [public documentation][28].
 
 **Parameters**
 
-- `config` **[Object][19]?** 
-  - `config.ownerId` **[string][20]?** 
+- `config` **[Object][21]?** 
+  - `config.ownerId` **[string][22]?** 
 
 Returns **MapiRequest** 
+
+## Styles
+
+Styles API service.
+
+### getStyle
+
+Get a style.
+
+See the [public documentation][29].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### createStyle
+
+Create a style.
+
+See the [public documentation][30].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.style` **[Object][21]** Stylesheet JSON object.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### updateStyle
+
+Update a style.
+
+See the [public documentation][31].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.style` **[Object][21]** Stylesheet JSON object.
+  - `config.lastKnownModification` **([string][22] \| [number][32] \| [Date][33])?** Datetime of last
+      known update. Passed as 'If-Unmodified-Since' HTTP header.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### deleteStyle
+
+Delete a style.
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### listStyles
+
+List styles in your account.
+
+**Parameters**
+
+- `config` **[Object][21]?** 
+  - `config.start` **[string][22]?** The style ID of the last style in the
+      previous page.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### createStyleIcon
+
+Add an icon to a style.
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.iconId` **[string][22]** 
+  - `config.file` **([Blob][34] \| [ArrayBuffer][35] \| [string][22] | ReadableStream)** An SVG file.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### deleteStyleIcon
+
+Remove an icon from a style.
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.iconId` **[string][22]** 
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### getStyleSprite
+
+Get a style sprite's image or JSON document.
+
+See [the public documentation][36].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.styleId` **[string][22]** 
+  - `config.format` **(`"json"` \| `"png"`)**  (optional, default `"json"`)
+  - `config.highRes` **[boolean][37]?** If true, returns spritesheet with 2x
+      resolution.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### getFontGlyphRange
+
+Get a font glyph range.
+
+See [the public documentation][38].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+  - `config.fonts` **[Array][25]&lt;[string][22]>** An array of font names.
+  - `config.start` **[number][32]** Character code of the starting glyph.
+  - `config.end` **[number][32]** Character code of the last glyph,
+      typically equivalent to`config.start + 255`.
+  - `config.ownerId` **[string][22]?** 
+
+Returns **MapiRequest** 
+
+### getEmbeddableHtml
+
+Get embeddable HTML displaying a map.
+
+See [the public documentation][39].
+
+**Parameters**
+
+- `config` **[Object][21]** 
+- `styleId` **[string][22]** 
+- `scrollZoom` **[boolean][37]** If `false`, zooming the map by scrolling will
+    be disbaled. (optional, default `true`)
+- `title` **[boolean][37]** If `true`, the map's title and owner is displayed
+    in the upper right corner of the map. (optional, default `false`)
+- `ownerId` **ownerId?** 
 
 [1]: #tilesets
 
 [2]: #listtilesets
 
-[3]: #styles
+[3]: #tokens
 
-[4]: #getstyle
+[4]: #listtokens
 
-[5]: #createstyle
+[5]: #createtoken
 
-[6]: #updatestyle
+[6]: #updatetoken
 
-[7]: #deletestyle
+[7]: #deletetoken
 
-[8]: #liststyles
+[8]: #listscopes
 
-[9]: #createstyleicon
+[9]: #styles
 
-[10]: #deletestyleicon
+[10]: #getstyle
 
-[11]: #getstylespritejson
+[11]: #createstyle
 
-[12]: #tokens
+[12]: #updatestyle
 
-[13]: #listtokens
+[13]: #deletestyle
 
-[14]: #createtoken
+[14]: #liststyles
 
-[15]: #updatetoken
+[15]: #createstyleicon
 
-[16]: #deletetoken
+[16]: #deletestyleicon
 
-[17]: #listscopes
+[17]: #getstylesprite
 
-[18]: https://www.mapbox.com/api-documentation/#list-tilesets
+[18]: #getfontglyphrange
 
-[19]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[19]: #getembeddablehtml
 
-[20]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[20]: https://www.mapbox.com/api-documentation/#list-tilesets
 
-[21]: https://www.mapbox.com/api-documentation/#retrieve-a-style
+[21]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[22]: https://www.mapbox.com/api-documentation/#create-a-style
+[22]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[23]: https://www.mapbox.com/api-documentation/#update-a-style
+[23]: https://www.mapbox.com/api-documentation/#list-tokens
 
-[24]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[24]: https://www.mapbox.com/api-documentation/#create-token
 
-[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
+[25]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[26]: https://developer.mozilla.org/docs/Web/API/Blob
+[26]: https://www.mapbox.com/api-documentation/#update-a-token
 
-[27]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+[27]: https://www.mapbox.com/api-documentation/?language=cURL#delete-a-token
 
-[28]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[28]: https://www.mapbox.com/api-documentation/#list-scopes
 
-[29]: https://www.mapbox.com/api-documentation/#list-tokens
+[29]: https://www.mapbox.com/api-documentation/#retrieve-a-style
 
-[30]: https://www.mapbox.com/api-documentation/#create-token
+[30]: https://www.mapbox.com/api-documentation/#create-a-style
 
-[31]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[31]: https://www.mapbox.com/api-documentation/#update-a-style
 
-[32]: https://www.mapbox.com/api-documentation/#update-a-token
+[32]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[33]: https://www.mapbox.com/api-documentation/?language=cURL#delete-a-token
+[33]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
 
-[34]: https://www.mapbox.com/api-documentation/#list-scopes
+[34]: https://developer.mozilla.org/docs/Web/API/Blob
+
+[35]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+
+[36]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-a-sprite-image-or-json
+
+[37]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+
+[38]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-font-glyph-ranges
+
+[39]: https://www.mapbox.com/api-documentation/?language=JavaScript#embed-a-style

--- a/lib/classes/mapi-response.js
+++ b/lib/classes/mapi-response.js
@@ -27,7 +27,11 @@ function MapiResponse(request, responseData) {
   this.headers = responseData.headers;
   this.rawBody = responseData.body;
   this.statusCode = responseData.statusCode;
-  this.body = JSON.parse(responseData.body || '{}');
+  try {
+    this.body = JSON.parse(responseData.body || '{}');
+  } catch (parseError) {
+    this.body = responseData.body;
+  }
   this.links = parseLinkHeader(this.headers.link);
 }
 

--- a/lib/helpers/__tests__/url-utils.test.js
+++ b/lib/helpers/__tests__/url-utils.test.js
@@ -70,6 +70,15 @@ describe('appendQueryObject', () => {
       })
     ).toBe('/foo/bar?test=one%2Ctwo');
   });
+
+  test('skips undefined properties', () => {
+    expect(
+      appendQueryObject('/foo/bar', {
+        one: undefined,
+        two: 2
+      })
+    ).toBe('/foo/bar?two=2');
+  });
 });
 
 describe('prependOrigin', () => {

--- a/lib/helpers/url-utils.js
+++ b/lib/helpers/url-utils.js
@@ -51,6 +51,9 @@ function appendQueryObject(url, queryObject) {
   var result = url;
   Object.keys(queryObject).forEach(function(key) {
     var value = queryObject[key];
+    if (value === undefined) {
+      return;
+    }
     if (Array.isArray(value)) {
       value = value
         .filter(function(v) {

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -150,9 +150,9 @@ describe('deleteStyleIcon', () => {
   });
 });
 
-describe('getStyleSpriteJson', () => {
-  test('works', () => {
-    styles.getStyleSpriteJson({
+describe('getStyleSprite', () => {
+  test('fetches JSON by default', () => {
+    styles.getStyleSprite({
       styleId: 'foo'
     });
     expect(tu.requestConfig(styles)).toEqual({
@@ -160,14 +160,14 @@ describe('getStyleSpriteJson', () => {
       method: 'GET',
       params: {
         styleId: 'foo',
-        ownerId: undefined,
         fileName: 'sprite.json'
       }
     });
   });
 
-  test('high resolution', () => {
-    styles.getStyleSpriteJson({
+  test('high resolution JSON', () => {
+    styles.getStyleSprite({
+      format: 'json',
       styleId: 'foo',
       highRes: true
     });
@@ -176,9 +176,111 @@ describe('getStyleSpriteJson', () => {
       method: 'GET',
       params: {
         styleId: 'foo',
-        ownerId: undefined,
         fileName: 'sprite@2x.json'
       }
+    });
+  });
+
+  test('regular resolution PNG', () => {
+    styles.getStyleSprite({
+      format: 'png',
+      styleId: 'foo'
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      method: 'GET',
+      params: {
+        styleId: 'foo',
+        fileName: 'sprite.png'
+      }
+    });
+  });
+
+  test('high resolution PNG', () => {
+    styles.getStyleSprite({
+      format: 'png',
+      styleId: 'foo',
+      highRes: true
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      method: 'GET',
+      params: {
+        styleId: 'foo',
+        fileName: 'sprite@2x.png'
+      }
+    });
+  });
+});
+
+describe('getFontGlyphRange', () => {
+  test('with one font', () => {
+    styles.getFontGlyphRange({
+      fonts: ['Ubuntu Bold'],
+      start: 0,
+      end: 255
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/fonts/v1/:ownerId/:fontList/:fileName',
+      method: 'GET',
+      params: {
+        fontList: 'Ubuntu Bold',
+        fileName: '0-255.pbf'
+      }
+    });
+  });
+
+  test('with multiple font', () => {
+    styles.getFontGlyphRange({
+      fonts: ['Ubuntu Bold', 'Ubuntu Light'],
+      start: 0,
+      end: 255
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/fonts/v1/:ownerId/:fontList/:fileName',
+      method: 'GET',
+      params: {
+        fontList: 'Ubuntu Bold,Ubuntu Light',
+        fileName: '0-255.pbf'
+      }
+    });
+  });
+});
+
+describe('getEmbeddableHtml', () => {
+  test('works', () => {
+    styles.getEmbeddableHtml({
+      styleId: 'foo'
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/styles/v1/:ownerId/:fileName',
+      method: 'GET',
+      params: {
+        fileName: 'foo.html'
+      },
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      query: { zoomwheel: 'true', title: 'false' }
+    });
+  });
+
+  test('with non-default scrollZoom and title', () => {
+    styles.getEmbeddableHtml({
+      styleId: 'foo',
+      scrollZoom: false,
+      title: true
+    });
+    expect(tu.requestConfig(styles)).toEqual({
+      path: '/styles/v1/:ownerId/:fileName',
+      method: 'GET',
+      params: {
+        fileName: 'foo.html'
+      },
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      query: { zoomwheel: 'false', title: 'true' }
     });
   });
 });

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -258,7 +258,7 @@ describe('getEmbeddableHtml', () => {
       params: {
         fileName: 'foo.html'
       },
-      query: { zoomwheel: 'true', title: 'false' }
+      query: {}
     });
   });
 

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -216,7 +216,7 @@ describe('getStyleSprite', () => {
 describe('getFontGlyphRange', () => {
   test('with one font', () => {
     styles.getFontGlyphRange({
-      fonts: ['Ubuntu Bold'],
+      fonts: 'Ubuntu Bold',
       start: 0,
       end: 255
     });
@@ -224,7 +224,7 @@ describe('getFontGlyphRange', () => {
       path: '/fonts/v1/:ownerId/:fontList/:fileName',
       method: 'GET',
       params: {
-        fontList: 'Ubuntu Bold',
+        fontList: ['Ubuntu Bold'],
         fileName: '0-255.pbf'
       }
     });
@@ -240,7 +240,7 @@ describe('getFontGlyphRange', () => {
       path: '/fonts/v1/:ownerId/:fontList/:fileName',
       method: 'GET',
       params: {
-        fontList: 'Ubuntu Bold,Ubuntu Light',
+        fontList: ['Ubuntu Bold', 'Ubuntu Light'],
         fileName: '0-255.pbf'
       }
     });
@@ -258,9 +258,6 @@ describe('getEmbeddableHtml', () => {
       params: {
         fileName: 'foo.html'
       },
-      headers: {
-        'Content-Type': 'text/plain'
-      },
       query: { zoomwheel: 'true', title: 'false' }
     });
   });
@@ -276,9 +273,6 @@ describe('getEmbeddableHtml', () => {
       method: 'GET',
       params: {
         fileName: 'foo.html'
-      },
-      headers: {
-        'Content-Type': 'text/plain'
       },
       query: { zoomwheel: 'false', title: 'true' }
     });

--- a/services/service-helpers/validator.js
+++ b/services/service-helpers/validator.js
@@ -100,6 +100,21 @@ v.oneOf = function() {
   });
 };
 
+v.stringOrArrayOfStrings = wrapCheck(function(value) {
+  if (typeof value === 'string') {
+    return;
+  }
+  if (
+    Array.isArray(value) &&
+    value.every(function(x) {
+      return typeof x === 'string';
+    })
+  ) {
+    return;
+  }
+  return 'must be a string or an array of strings';
+});
+
 function required(value) {
   if (isEmpty(value)) {
     return 'is required';

--- a/services/service-helpers/validator.js
+++ b/services/service-helpers/validator.js
@@ -88,6 +88,18 @@ v.file = wrapCheck(function(value) {
   return 'must be a filename or Readable stream';
 });
 
+v.oneOf = function() {
+  var possibilities = Array.prototype.slice.call(arguments);
+  return wrapCheck(function(value) {
+    for (var i = 0; i < possibilities.length; i++) {
+      if (value === possibilities[i]) {
+        return;
+      }
+    }
+    return 'must be one of ' + possibilities.join(', ');
+  });
+};
+
 function required(value) {
   if (isEmpty(value)) {
     return 'is required';

--- a/services/styles.js
+++ b/services/styles.js
@@ -254,7 +254,7 @@ Styles.getStyleSprite = function(config) {
  * See [the public documentation](https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-font-glyph-ranges).
  *
  * @param {Object} config
- * @param {Array<string>} config.fonts - An array of font names.
+ * @param {string|Array<string>} config.fonts - An array of font names.
  * @param {number} config.start - Character code of the starting glyph.
  * @param {number} config.end - Character code of the last glyph,
  *   typically equivalent to`config.start + 255`.
@@ -264,7 +264,7 @@ Styles.getStyleSprite = function(config) {
 Styles.getFontGlyphRange = function(config) {
   v.validate(
     {
-      fonts: v.arrayOfStrings.required,
+      fonts: v.stringOrArrayOfStrings.required,
       start: v.number.required,
       end: v.number.required,
       ownerId: v.string
@@ -272,14 +272,13 @@ Styles.getFontGlyphRange = function(config) {
     config
   );
 
-  var fontList = config.fonts.join(',');
   var fileName = config.start + '-' + config.end + '.pbf';
 
   return this.client.createRequest({
     method: 'GET',
     path: '/fonts/v1/:ownerId/:fontList/:fileName',
     params: xtend(pick(config, ['ownerId']), {
-      fontList: fontList,
+      fontList: [].concat(config.fonts),
       fileName: fileName
     })
   });
@@ -322,11 +321,6 @@ Styles.getEmbeddableHtml = function(config) {
     query: {
       zoomwheel: String(scrollZoom),
       title: String(title)
-    },
-    headers: {
-      // Makes this request a "simple" request, so an OPTIONS preflight
-      // request is not sent from the browser, which the server rejects.
-      'Content-Type': 'text/plain'
     }
   });
 };

--- a/services/styles.js
+++ b/services/styles.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var xtend = require('xtend');
 var v = require('./service-helpers/validator');
 var pick = require('./service-helpers/pick');
 var createServiceFactory = require('./service-helpers/create-service-factory');
@@ -212,34 +213,120 @@ Styles.deleteStyleIcon = function(config) {
 };
 
 /**
- * Get a style's spritesheet in the JSON format.
+ * Get a style sprite's image or JSON document.
+ *
+ * See [the public documentation](https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-a-sprite-image-or-json).
  *
  * @param {Object} config
  * @param {string} config.styleId
+ * @param {'json' | 'png'} [config.format="json"]
  * @param {boolean} [config.highRes] - If true, returns spritesheet with 2x
  *   resolution.
  * @param {string} [config.ownerId]
  * @return {MapiRequest}
  */
-Styles.getStyleSpriteJson = function(config) {
+Styles.getStyleSprite = function(config) {
   v.validate(
     {
       styleId: v.string.required,
+      format: v.oneOf('json', 'png'),
       highRes: v.boolean,
       ownerId: v.string
     },
     config
   );
 
-  var fileName = 'sprite' + (config.highRes ? '@2x' : '') + '.json';
+  var format = config.format || 'json';
+  var fileName = 'sprite' + (config.highRes ? '@2x' : '') + '.' + format;
 
   return this.client.createRequest({
     method: 'GET',
     path: '/styles/v1/:ownerId/:styleId/:fileName',
-    params: {
-      fileName: fileName,
-      ownerId: config.ownerId,
-      styleId: config.styleId
+    params: xtend(pick(config, ['ownerId', 'styleId']), {
+      fileName: fileName
+    })
+  });
+};
+
+/**
+ * Get a font glyph range.
+ *
+ * See [the public documentation](https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-font-glyph-ranges).
+ *
+ * @param {Object} config
+ * @param {Array<string>} config.fonts - An array of font names.
+ * @param {number} config.start - Character code of the starting glyph.
+ * @param {number} config.end - Character code of the last glyph,
+ *   typically equivalent to`config.start + 255`.
+ * @param {string} [config.ownerId]
+ * @return {MapiRequest}
+ */
+Styles.getFontGlyphRange = function(config) {
+  v.validate(
+    {
+      fonts: v.arrayOfStrings.required,
+      start: v.number.required,
+      end: v.number.required,
+      ownerId: v.string
+    },
+    config
+  );
+
+  var fontList = config.fonts.join(',');
+  var fileName = config.start + '-' + config.end + '.pbf';
+
+  return this.client.createRequest({
+    method: 'GET',
+    path: '/fonts/v1/:ownerId/:fontList/:fileName',
+    params: xtend(pick(config, ['ownerId']), {
+      fontList: fontList,
+      fileName: fileName
+    })
+  });
+};
+
+/**
+ * Get embeddable HTML displaying a map.
+ *
+ * See [the public documentation](https://www.mapbox.com/api-documentation/?language=JavaScript#embed-a-style).
+ *
+ * @param {Object} config
+ * @param {string} styleId
+ * @param {boolean} [scrollZoom=true] - If `false`, zooming the map by scrolling will
+ *   be disbaled.
+ * @param {boolean} [title=false] - If `true`, the map's title and owner is displayed
+ *   in the upper right corner of the map.
+ * @param {ownerId} [ownerId]
+ */
+Styles.getEmbeddableHtml = function(config) {
+  v.validate(
+    {
+      styleId: v.string.required,
+      scrollZoom: v.boolean,
+      title: v.boolean,
+      ownerId: v.string
+    },
+    config
+  );
+
+  var scrollZoom = config.scrollZoom !== undefined ? config.scrollZoom : true;
+  var title = config.title !== undefined ? config.title : false;
+  var fileName = config.styleId + '.html';
+
+  return this.client.createRequest({
+    method: 'GET',
+    path: '/styles/v1/:ownerId/:fileName',
+    params: xtend(pick(config, ['ownerId']), {
+      fileName: fileName
+    }),
+    query: {
+      zoomwheel: String(scrollZoom),
+      title: String(title)
+    },
+    headers: {
+      // Makes this request a "simple" request, so an OPTIONS preflight
+      // request is not sent from the browser, which the server rejects.
+      'Content-Type': 'text/plain'
     }
   });
 };

--- a/services/styles.js
+++ b/services/styles.js
@@ -308,9 +308,14 @@ Styles.getEmbeddableHtml = function(config) {
     config
   );
 
-  var scrollZoom = config.scrollZoom !== undefined ? config.scrollZoom : true;
-  var title = config.title !== undefined ? config.title : false;
   var fileName = config.styleId + '.html';
+  var query = {};
+  if (config.scrollZoom !== undefined) {
+    query.zoomwheel = String(config.scrollZoom);
+  }
+  if (config.title !== undefined) {
+    query.title = String(config.title);
+  }
 
   return this.client.createRequest({
     method: 'GET',
@@ -318,10 +323,7 @@ Styles.getEmbeddableHtml = function(config) {
     params: xtend(pick(config, ['ownerId']), {
       fileName: fileName
     }),
-    query: {
-      zoomwheel: String(scrollZoom),
-      title: String(title)
-    }
+    query: query
   });
 };
 

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -658,30 +658,6 @@ function testSharedInterface(createClient) {
     });
   });
 
-  describe('failure to parse body as JSON', () => {
-    let request;
-    beforeEach(() => {
-      server.setResponse((req, res) => {
-        res.append('Content-Type', 'application/json; charset=utf-8');
-        res.send('{egg}');
-      });
-
-      const accessToken = mockToken();
-      const client = createLocalClient({ accessToken });
-      request = client.createRequest({
-        method: 'GET',
-        path: '/styles/v1/:ownerId/:styleId',
-        params: { styleId: 'foo' }
-      });
-    });
-
-    test(`request.send's Promise rejects with a SyntaxError`, () => {
-      return expectRejection(request.send(), error => {
-        expect(error.message).toMatch(/Unexpected token e/);
-      });
-    });
-  });
-
   describe('paginated GET that succeeds for every page', () => {
     let request;
     beforeEach(() => {

--- a/test/try-browser/index.html
+++ b/test/try-browser/index.html
@@ -30,8 +30,9 @@
 <pre><code style="display:block;">tryServiceMethod(
   service: string,
   method: string,
-  config?: Object,
-  accessToken?: string
+  config: ?Object,
+  accessToken: ?string,
+  callback: ?(response) => void,
 )</code></pre>
   </p>
   <p>

--- a/test/try-browser/try-browser.js
+++ b/test/try-browser/try-browser.js
@@ -10,7 +10,8 @@ window.tryServiceMethod = function(
   serviceName,
   methodName,
   config,
-  accessToken
+  accessToken,
+  callback
 ) {
   config = config || {};
   accessToken = accessToken || window.MAPBOX_ACCESS_TOKEN;
@@ -44,9 +45,13 @@ window.tryServiceMethod = function(
 
   service[methodName](config)
     .send()
-    .then(log, log);
+    .then(
+      function(response) {
+        console.log(response);
+        if (callback) callback(response);
+      },
+      function(error) {
+        console.error(error);
+      }
+    );
 };
-
-function log(msg) {
-  console.log(msg);
-}


### PR DESCRIPTION
Style#getStyleSprite replaces getStyleSpriteJson to allow for PNGs, also.

Removes the requirement that the response's body be parseable as JSON, because these endpoints receive non-JSON.

@kepta for review.

cc @emilymdubois 