### PR TITLE
Allow unencoded commas in URI parts that are lists

### DIFF
--- a/lib/helpers/__tests__/url-utils.test.js
+++ b/lib/helpers/__tests__/url-utils.test.js
@@ -29,6 +29,12 @@ describe('appendQueryParam', () => {
       )
     ).toBe('foo?bar=baz&cat=cyrus&dog=penny&horse=ed&mouse=peter');
   });
+
+  test('encodes everything except commas separating items in array values', () => {
+    expect(appendQueryParam('foo', '#bar', ['a?', 'b,d', 'c&'])).toBe(
+      'foo?%23bar=a%3F,b%2Cd,c%26'
+    );
+  });
 });
 
 describe('appendQueryObject', () => {
@@ -96,5 +102,15 @@ describe('prependOrigin', () => {
 describe('interpolateRouteParams', () => {
   test('returns route if no params are provided', () => {
     expect(interpolateRouteParams('/foo/bar')).toBe('/foo/bar');
+  });
+
+  test('encodes all values except commas separating items in array values', () => {
+    expect(
+      interpolateRouteParams('/foo/:a/:b/:c', {
+        a: '#bar',
+        b: ['a?', 'c&'],
+        c: 'b,d'
+      })
+    ).toBe('/foo/%23bar/a%3F,c%26/b%2Cd');
   });
 });

--- a/lib/helpers/url-utils.js
+++ b/lib/helpers/url-utils.js
@@ -1,11 +1,26 @@
 'use strict';
 
+// Encode each item of an array individually. The comma
+// delimiters should not themselves be encoded.
+function encodeArray(arrayValue) {
+  return arrayValue.map(encodeURIComponent).join(',');
+}
+
+function encodeValue(value) {
+  if (Array.isArray(value)) {
+    return encodeArray(value);
+  }
+  return encodeURIComponent(String(value));
+}
+
 /**
  * Append a query parameter to a URL.
  *
  * @param {string} url
  * @param {string} key
- * @param {string|number|boolean} [value]
+ * @param {string|number|boolean|Array<*>>} [value] - Provide an array
+ *   if the value is a list and commas between values need to be
+ *   preserved, unencoded.
  * @returns {string} - Modified URL.
  */
 function appendQueryParam(url, key, value) {
@@ -15,7 +30,7 @@ function appendQueryParam(url, key, value) {
   var punctuation = /\?/.test(url) ? '&' : '?';
   var query = encodeURIComponent(key);
   if (value !== undefined && value !== '' && value !== true) {
-    query += '=' + encodeURIComponent(String(value));
+    query += '=' + encodeValue(value);
   }
   return '' + url + punctuation + query;
 }
@@ -75,6 +90,9 @@ function prependOrigin(url, origin) {
  *
  * @param {string} route
  * @param {Object} [params] - Values should be primitives
+ *   or arrays of primitives. Provide an array if the value
+ *   is a list and commas between values need to be
+ *   preserved, unencoded.
  * @returns {string} - Modified URL.
  */
 function interpolateRouteParams(route, params) {
@@ -86,7 +104,7 @@ function interpolateRouteParams(route, params) {
     if (value === undefined) {
       throw new Error('Unspecified route parameter ' + paramId);
     }
-    var preppedValue = encodeURIComponent(String(value));
+    var preppedValue = encodeValue(value);
     return '/' + preppedValue;
   });
 }


### PR DESCRIPTION
While looking into implementing the Tilequery service, I found that we'll need our encoding functions to accept arrays of values that it would render as encoded items separated by unencoded commas. 

For example, the following URL will work: `/v4/{map_id_1},{map_id_2},{map_id_3}/tilequery/-122.42901,37.80633.json?layers=poi_label,building`. But it will *not* work if you encode the commas within the route params or query string, like this: `/v4/{map_id_1}%2C{map_id_2}%2C{map_id_3}/tilequery/-122.42901%2C37.80633.json?layers=poi_label%2Cbuilding`.

@kepta for review.