### PR TITLE
Smarter default application of Content-Type: application/json

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -114,6 +114,8 @@ The `emitter` property is an `EventEmitter` that emits the following events:
     be interpolated the path.
 - `headers` **[Object][12]** The request's headers,
 - `body` **([Object][12] | null)** A JSON body to send with the request.
+    If the request has a body, it will also be sent with the header
+    'Content-Type: application/json'.
 - `file` **([Blob][20] \| [ArrayBuffer][21] \| [string][11] | ReadStream)** A file to
     send with the request. The browser client accepts Blobs and ArrayBuffers;
     the Node client accepts strings (filepaths) and ReadStreams.

--- a/lib/classes/__tests__/mapi-request.test.js
+++ b/lib/classes/__tests__/mapi-request.test.js
@@ -48,10 +48,7 @@ test('sets instance fields, minimal options', () => {
     client,
     path: 'mockUrl',
     method: 'MOCK_METHOD',
-    headers: {
-      'content-type': 'application/json',
-      accept: 'application/json'
-    }
+    headers: {}
   });
 });
 

--- a/lib/classes/mapi-request.js
+++ b/lib/classes/mapi-request.js
@@ -44,6 +44,8 @@ var requestId = 1;
  *   be interpolated the path.
  * @property {Object} headers - The request's headers,
  * @property {Object|null} body - A JSON body to send with the request.
+ *   If the request has a body, it will also be sent with the header
+ *   'Content-Type: application/json'.
  * @property {Blob|ArrayBuffer|string|ReadStream} file - A file to
  *   send with the request. The browser client accepts Blobs and ArrayBuffers;
  *   the Node client accepts strings (filepaths) and ReadStreams.
@@ -72,17 +74,19 @@ function MapiRequest(client, options) {
     );
   }
 
-  var preppedHeaders = {
-    'content-type': 'application/json',
-    accept: 'application/json'
-  };
-  var headers = options.headers;
-  if (headers) {
-    // Disallows duplicate header names.
-    Object.keys(headers).forEach(function(name) {
-      preppedHeaders[name.toLowerCase()] = headers[name];
-    });
+  var defaultHeaders = {};
+  if (options.body) {
+    defaultHeaders['content-type'] = 'application/json';
   }
+
+  var headersWithDefaults = xtend(defaultHeaders, options.headers);
+
+  // Disallows duplicate header names of mixed case,
+  // e.g. Content-Type and content-type.
+  var headers = Object.keys(headersWithDefaults).reduce(function(memo, name) {
+    memo[name.toLowerCase()] = headersWithDefaults[name];
+    return memo;
+  }, {});
 
   this.id = requestId++;
   this._options = options;
@@ -100,7 +104,7 @@ function MapiRequest(client, options) {
   this.params = options.params || {};
   this.body = options.body || null;
   this.file = options.file || null;
-  this.headers = preppedHeaders;
+  this.headers = headers;
 }
 
 MapiRequest.prototype.url = function url(accessToken) {

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -131,10 +131,7 @@ describe('createStyleIcon', () => {
       path: '/styles/v1/:ownerId/:styleId/sprite/:iconId',
       method: 'PUT',
       params: { styleId: 'foo', iconId: 'bar' },
-      file: 'path/to/file.svg',
-      headers: {
-        'Content-Type': 'application/octet-stream'
-      }
+      file: 'path/to/file.svg'
     });
   });
 });

--- a/services/styles.js
+++ b/services/styles.js
@@ -181,10 +181,7 @@ Styles.createStyleIcon = function(config) {
     method: 'PUT',
     path: '/styles/v1/:ownerId/:styleId/sprite/:iconId',
     params: pick(config, ['ownerId', 'styleId', 'iconId']),
-    file: config.file,
-    headers: {
-      'Content-Type': 'application/octet-stream'
-    }
+    file: config.file
   });
 };
 

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -371,19 +371,19 @@ function testSharedInterface(createClient) {
       client = createLocalClient({ accessToken });
     });
 
-    test('default headers', () => {
+    test('default headers with body', () => {
       const sendRequest = () => {
         return client
           .createRequest({
-            method: 'GET',
-            path: '/styles/v1/:ownerId'
+            method: 'POST',
+            path: '/styles/v1/:ownerId',
+            body: { style: {} }
           })
           .send();
       };
       return server.captureRequest(sendRequest).then(req => {
         expect(req.headers).toMatchObject({
-          'content-type': 'application/json',
-          accept: 'application/json'
+          'content-type': 'application/json'
         });
       });
     });
@@ -392,8 +392,9 @@ function testSharedInterface(createClient) {
       const sendRequest = () => {
         return client
           .createRequest({
-            method: 'GET',
+            method: 'POST',
             path: '/styles/v1/:ownerId',
+            body: { style: {} },
             headers: {
               'Content-Type': 'application/octet-stream',
               Accept: 'text/csv'
@@ -425,8 +426,6 @@ function testSharedInterface(createClient) {
       };
       return server.captureRequest(sendRequest).then(req => {
         expect(req.headers).toMatchObject({
-          'content-type': 'application/json',
-          accept: 'application/json',
           'if-unmodified-since': 'Wed, 11 Apr 2018 17:09:50 GMT',
           'x-horse-name': 'Steuben',
           'x-dog-name': 'Paul, Cat'


### PR DESCRIPTION
This header should only be applied on requests with bodies
(POST, PUT, PATCH sending JSON). By selectively applying the
default, we save ourselves from having to overwrite it in a
couple of situations: when we are sending something other than
JSON (e.g. Styles#createStyleIcon); and when the API accepts
only GET requests and is not configured to handle CORS (so
will not accept "Content-Type: application/json").

An example of that second case (no CORS configuration) is here: https://github.com/mapbox/mapbox-sdk-js/pull/224/files#diff-46dd6b5ebdd5fc8bad78ed5b7883166fR265

@emilymdubois: I believe the application of this header only when there is a JSON body matches what Studio's internal client has been doing all along, so this change should be safe. Does it seem ok to you?

cc @kepta 