### PR TITLE
Change country config to countries

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -533,7 +533,7 @@ See the [public documentation][97].
 - `config` **[Object][64]** 
   - `config.query` **[string][65]** A place name.
   - `config.mode` **(`"mapbox.places"` \| `"mapbox.places-permanent"`)** Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding. (optional, default `"mapbox.places"`)
-  - `config.country` **[Array][74]&lt;[string][65]>?** Limits results to one or more countries.
+  - `config.countries` **[Array][74]&lt;[string][65]>?** Limits results to the specified countries.
       Each item in the array should be an [ISO 3166 alpha 2 country code][98].
   - `config.proximity` **[Coordinates][77]?** Bias local results based on a provided location.
   - `config.types` **[Array][74]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
@@ -557,7 +557,7 @@ See the [public documentation][102].
 - `config` **[Object][64]** 
   - `config.query` **[Coordinates][77]** Coordinates at which features will be searched.
   - `config.mode` **(`"mapbox.places"` \| `"mapbox.places-permanent"`)** Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding. (optional, default `"mapbox.places"`)
-  - `config.country` **[Array][74]&lt;[string][65]>?** Limits results to one or more countries.
+  - `config.countries` **[Array][74]&lt;[string][65]>?** Limits results to the specified countries.
       Each item in the array should be an [ISO 3166 alpha 2 country code][98].
   - `config.types` **[Array][74]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
   - `config.bbox` **[BoundingBox][99]?** Limit results to a bounding box.

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -29,7 +29,7 @@ describe('forwardGeocode', () => {
     geocoding.forwardGeocode({
       query: 'Tucson',
       mode: 'mapbox.places-permanent',
-      country: ['AO', 'AR'],
+      countries: ['AO', 'AR'],
       proximity: [3, 4],
       types: ['country', 'region'],
       autocomplete: true,
@@ -78,7 +78,7 @@ describe('reverseGeocode', () => {
     geocoding.reverseGeocode({
       query: [15, 14],
       mode: 'mapbox.places-permanent',
-      country: ['AO', 'AR'],
+      countries: ['AO', 'AR'],
       types: ['country', 'region'],
       bbox: [1, 2, 3, 4],
       limit: 3,

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var xtend = require('xtend');
 var v = require('./service-helpers/validator');
 var pick = require('./service-helpers/pick');
 var createServiceFactory = require('./service-helpers/create-service-factory');
@@ -33,7 +34,7 @@ var featureTypes = [
  * @param {Object} config
  * @param {string} config.query - A place name.
  * @param {'mapbox.places'|'mapbox.places-permanent'} [config.mode="mapbox.places"] - Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding.
- * @param {Array<string>} [config.country] - Limits results to one or more countries.
+ * @param {Array<string>} [config.countries] - Limits results to the specified countries.
  *   Each item in the array should be an [ISO 3166 alpha 2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
  * @param {Coordinates} [config.proximity] - Bias local results based on a provided location.
  * @param {Array<'country'|'region'|'postcode'|'district'|'place'|'locality'|'neighborhood'|'address'|'poi'|'poi.landmark'>} [config.types] - Filter results by feature types.
@@ -49,7 +50,7 @@ Geocoding.forwardGeocode = function(config) {
   v.assertShape({
     query: v.required(v.string),
     mode: v.oneOf('mapbox.places', 'mapbox.places-permanent'),
-    country: v.arrayOf(v.string),
+    countries: v.arrayOf(v.string),
     proximity: v.coordinates,
     types: v.arrayOf(v.oneOf(featureTypes)),
     autocomplete: v.boolean,
@@ -64,15 +65,17 @@ Geocoding.forwardGeocode = function(config) {
     method: 'GET',
     path: '/geocoding/v5/:mode/:query.json',
     params: pick(config, ['mode', 'query']),
-    query: pick(config, [
-      'country',
-      'proximity',
-      'types',
-      'autocomplete',
-      'bbox',
-      'limit',
-      'language'
-    ])
+    query: xtend(
+      { country: config.countries },
+      pick(config, [
+        'proximity',
+        'types',
+        'autocomplete',
+        'bbox',
+        'limit',
+        'language'
+      ])
+    )
   });
 };
 
@@ -84,7 +87,7 @@ Geocoding.forwardGeocode = function(config) {
  * @param {Object} config
  * @param {Coordinates} config.query - Coordinates at which features will be searched.
  * @param {'mapbox.places'|'mapbox.places-permanent'} [config.mode="mapbox.places"] - Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding.
- * @param {Array<string>} [config.country] - Limits results to one or more countries.
+ * @param {Array<string>} [config.countries] - Limits results to the specified countries.
  *   Each item in the array should be an [ISO 3166 alpha 2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
  * @param {Array<'country'|'region'|'postcode'|'district'|'place'|'locality'|'neighborhood'|'address'|'poi'|'poi.landmark'>} [config.types] - Filter results by feature types.
  * @param {BoundingBox} [config.bbox] - Limit results to a bounding box.
@@ -99,7 +102,7 @@ Geocoding.reverseGeocode = function(config) {
   v.assertShape({
     query: v.required(v.coordinates),
     mode: v.oneOf('mapbox.places', 'mapbox.places-permanent'),
-    country: v.arrayOf(v.string),
+    countries: v.arrayOf(v.string),
     types: v.arrayOf(v.oneOf(featureTypes)),
     bbox: v.arrayOf(v.number),
     limit: v.number,
@@ -113,14 +116,17 @@ Geocoding.reverseGeocode = function(config) {
     method: 'GET',
     path: '/geocoding/v5/:mode/:query.json',
     params: pick(config, ['mode', 'query']),
-    query: pick(config, [
-      'country',
-      'types',
-      'bbox',
-      'limit',
-      'language',
-      'reverseMode'
-    ])
+    query: xtend(
+      { country: config.countries },
+      pick(config, [
+        'country',
+        'types',
+        'bbox',
+        'limit',
+        'language',
+        'reverseMode'
+      ])
+    )
   });
 };
 


### PR DESCRIPTION
I checked whether all the request config options accepting arrays were named as plurals. I think this was the only exception.

@kepta for review.