### PR TITLE
Tidy docs by removing empty configs and ordering UploadableFile

### DIFF
--- a/conf/service-documentation.yml
+++ b/conf/service-documentation.yml
@@ -21,6 +21,6 @@ toc:
       - CustomMarkerOverlay
       - PathOverlay
       - GeoJsonOverlay
+      - UploadableFile
       - Coordinates
       - BoundingBox
-

--- a/docs/services.md
+++ b/docs/services.md
@@ -60,28 +60,28 @@
   - [CustomMarkerOverlay](#custommarkeroverlay)
   - [PathOverlay](#pathoverlay)
   - [GeoJsonOverlay](#geojsonoverlay)
+  - [UploadableFile](#uploadablefile)
   - [Coordinates](#coordinates)
   - [BoundingBox](#boundingbox)
-- [UploadableFile](#uploadablefile)
 
 ## Styles
 
 Styles API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][108].
+[the HTTP service documentation][103].
 
 ### getStyle
 
 Get a style.
 
-See the [corresponding HTTP service documentation][109].
+See the [corresponding HTTP service documentation][104].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -89,13 +89,13 @@ Returns **MapiRequest**
 
 Create a style.
 
-See the [corresponding HTTP service documentation][112].
+See the [corresponding HTTP service documentation][107].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.style` **[Object][110]** Stylesheet JSON object.
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.style` **[Object][105]** Stylesheet JSON object.
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -103,16 +103,16 @@ Returns **MapiRequest**
 
 Update a style.
 
-See the [corresponding HTTP service documentation][113].
+See the [corresponding HTTP service documentation][108].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
-  - `config.style` **[Object][110]** Stylesheet JSON object.
-  - `config.lastKnownModification` **([string][111] \| [number][114] \| [Date][115])?** Datetime of last
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
+  - `config.style` **[Object][105]** Stylesheet JSON object.
+  - `config.lastKnownModification` **([string][106] \| [number][109] \| [Date][110])?** Datetime of last
       known update. Passed as 'If-Unmodified-Since' HTTP header.
-  - `config.ownerId` **[string][111]?** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -122,9 +122,9 @@ Delete a style.
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -134,9 +134,9 @@ List styles in your account.
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.start` **[string][111]?** The style ID to start at, for paginated results.
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]?** 
+  - `config.start` **[string][106]?** The style ID to start at, for paginated results.
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -146,11 +146,11 @@ Add an icon to a style, or update an existing one.
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
-  - `config.iconId` **[string][111]** 
-  - `config.file` **[UploadableFile][116]** An SVG file.
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
+  - `config.iconId` **[string][106]** 
+  - `config.file` **[UploadableFile][111]** An SVG file.
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -160,10 +160,10 @@ Remove an icon from a style.
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
-  - `config.iconId` **[string][111]** 
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
+  - `config.iconId` **[string][106]** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -171,16 +171,16 @@ Returns **MapiRequest**
 
 Get a style sprite's image or JSON document.
 
-See [the corresponding HTTP service documentation][117].
+See [the corresponding HTTP service documentation][112].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.styleId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.styleId` **[string][106]** 
   - `config.format` **(`"json"` \| `"png"`)**  (optional, default `"json"`)
-  - `config.highRes` **[boolean][118]?** If true, returns spritesheet with 2x
+  - `config.highRes` **[boolean][113]?** If true, returns spritesheet with 2x
       resolution.
-  - `config.ownerId` **[string][111]?** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -188,16 +188,16 @@ Returns **MapiRequest**
 
 Get a font glyph range.
 
-See [the corresponding HTTP service documentation][119].
+See [the corresponding HTTP service documentation][114].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.fonts` **([string][111] \| [Array][120]&lt;[string][111]>)** An array of font names.
-  - `config.start` **[number][114]** Character code of the starting glyph.
-  - `config.end` **[number][114]** Character code of the last glyph,
+- `config` **[Object][105]** 
+  - `config.fonts` **([string][106] \| [Array][115]&lt;[string][106]>)** An array of font names.
+  - `config.start` **[number][109]** Character code of the starting glyph.
+  - `config.end` **[number][109]** Character code of the last glyph,
       typically equivalent to`config.start + 255`.
-  - `config.ownerId` **[string][111]?** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -205,15 +205,15 @@ Returns **MapiRequest**
 
 Get embeddable HTML displaying a map.
 
-See [the corresponding HTTP service documentation][121].
+See [the corresponding HTTP service documentation][116].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-- `styleId` **[string][111]** 
-- `scrollZoom` **[boolean][118]** If `false`, zooming the map by scrolling will
+- `config` **[Object][105]** 
+- `styleId` **[string][106]** 
+- `scrollZoom` **[boolean][113]** If `false`, zooming the map by scrolling will
     be disabled. (optional, default `true`)
-- `title` **[boolean][118]** If `true`, the map's title and owner is displayed
+- `title` **[boolean][113]** If `true`, the map's title and owner is displayed
     in the upper right corner of the map. (optional, default `false`)
 - `ownerId` **ownerId?** 
 
@@ -222,7 +222,7 @@ See [the corresponding HTTP service documentation][121].
 Static API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][122].
+[the HTTP service documentation][117].
 
 ### getStaticImage
 
@@ -234,29 +234,29 @@ SDK returned.
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.ownerId` **[string][111]** The owner of the map style.
-  - `config.styleId` **[string][111]** The map's style ID.
-  - `config.width` **[number][114]** Width of the image in pixels, between 1 and 1280.
-  - `config.height` **[number][114]** Height of the image in pixels, between 1 and 1280.
-  - `config.coordinates` **([Coordinates][123] \| `"auto"`)** `[longitude, latitude]`
+- `config` **[Object][105]** 
+  - `config.ownerId` **[string][106]** The owner of the map style.
+  - `config.styleId` **[string][106]** The map's style ID.
+  - `config.width` **[number][109]** Width of the image in pixels, between 1 and 1280.
+  - `config.height` **[number][109]** Height of the image in pixels, between 1 and 1280.
+  - `config.coordinates` **([Coordinates][118] \| `"auto"`)** `[longitude, latitude]`
       for the center of image; or `'auto'` to fit the map within the bounds of
       the overlay features.
-  - `config.zoom` **[number][114]** Between 0 and 20.
-  - `config.bearing` **[number][114]?** Between 0 and 360.
-  - `config.pitch` **[number][114]?** Between 0 and 60.
-  - `config.overlays` **[Array][120]&lt;Overlay>?** Overlays should be in z-index
+  - `config.zoom` **[number][109]** Between 0 and 20.
+  - `config.bearing` **[number][109]?** Between 0 and 360.
+  - `config.pitch` **[number][109]?** Between 0 and 60.
+  - `config.overlays` **[Array][115]&lt;Overlay>?** Overlays should be in z-index
       order: the first in the array will be on the bottom; the last will be on
-      the top. Overlays are objects that match one of the following types.-   [`SimpleMarkerOverlay`][97]
-    - [`CustomMarkerOverlay`][99]
-    - [`PathOverlay`][101]
-    - [`GeoJsonOverlay`][103]
-  - `config.highRes` **[boolean][118]**  (optional, default `false`)
-  - `config.insertOverlayBeforeLayer` **[string][111]?** The ID of the style layer
+      the top. Overlays are objects that match one of the following types.-   [`SimpleMarkerOverlay`][92]
+    - [`CustomMarkerOverlay`][94]
+    - [`PathOverlay`][96]
+    - [`GeoJsonOverlay`][98]
+  - `config.highRes` **[boolean][113]**  (optional, default `false`)
+  - `config.insertOverlayBeforeLayer` **[string][106]?** The ID of the style layer
       that overlays should be inserted *before*.
-  - `config.attribution` **[boolean][118]** Whether there is attribution
+  - `config.attribution` **[boolean][113]** Whether there is attribution
       on the map image. (optional, default `true`)
-  - `config.logo` **[boolean][118]** Whether there is a Mapbox logo
+  - `config.logo` **[boolean][113]** Whether there is a Mapbox logo
       on the map image. (optional, default `true`)
 
 Returns **MapiRequest** 
@@ -266,18 +266,18 @@ Returns **MapiRequest**
 Uploads API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][124].
+[the HTTP service documentation][119].
 
 ### listUploads
 
 List the statuses of all recent uploads.
 
-See the [corresponding HTTP service documentation][125].
+See the [corresponding HTTP service documentation][120].
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.reverse` **[boolean][118]?** List uploads in chronological order, rather than reverse chronological order.
+- `config` **[Object][105]?** 
+  - `config.reverse` **[boolean][113]?** List uploads in chronological order, rather than reverse chronological order.
 
 Returns **MapiRequest** 
 
@@ -285,11 +285,7 @@ Returns **MapiRequest**
 
 Create s3 credentials.
 
-See the [corresponding HTTP service documentation][126].
-
-#### Parameters
-
-- `config`  
+See the [corresponding HTTP service documentation][121].
 
 Returns **MapiRequest** 
 
@@ -297,15 +293,15 @@ Returns **MapiRequest**
 
 Create an upload.
 
-See the [corresponding HTTP service documentation][127].
+See the [corresponding HTTP service documentation][122].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.mapId` **[string][111]** The map ID to create or replace in the format `username.nameoftileset`.
+- `config` **[Object][105]** 
+  - `config.mapId` **[string][106]** The map ID to create or replace in the format `username.nameoftileset`.
       Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
-  - `config.s3Url` **[string][111]** HTTPS URL of the S3 object provided in the credential request or the dataset ID of an existing Mapbox dataset to be uploaded.
-  - `config.tilesetName` **[string][111]?** Name for the tileset. Limited to 64 characters.
+  - `config.s3Url` **[string][106]** HTTPS URL of the S3 object provided in the credential request or the dataset ID of an existing Mapbox dataset to be uploaded.
+  - `config.tilesetName` **[string][106]?** Name for the tileset. Limited to 64 characters.
 
 Returns **MapiRequest** 
 
@@ -313,12 +309,12 @@ Returns **MapiRequest**
 
 Get an upload's status.
 
-See the [corresponding HTTP service documentation][128].
+See the [corresponding HTTP service documentation][123].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.uploadId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.uploadId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -326,12 +322,12 @@ Returns **MapiRequest**
 
 Delete an upload.
 
-See the [corresponding HTTP service documentation][129].
+See the [corresponding HTTP service documentation][124].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.uploadId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.uploadId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -340,17 +336,13 @@ Returns **MapiRequest**
 Datasets API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][130].
+[the HTTP service documentation][125].
 
 ### listDatasets
 
 List datasets in your account.
 
-See the [corresponding HTTP service documentation][131].
-
-#### Parameters
-
-- `config`  
+See the [corresponding HTTP service documentation][126].
 
 Returns **MapiRequest** 
 
@@ -358,13 +350,13 @@ Returns **MapiRequest**
 
 Create a new, empty dataset.
 
-See the [corresponding HTTP service documentation][132].
+See the [corresponding HTTP service documentation][127].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.name` **[string][111]?** 
-  - `config.description` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.name` **[string][106]?** 
+  - `config.description` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -372,12 +364,12 @@ Returns **MapiRequest**
 
 Get metadata about a dataset.
 
-See the [corresponding HTTP service documentation][133].
+See the [corresponding HTTP service documentation][128].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -385,14 +377,14 @@ Returns **MapiRequest**
 
 Update user-defined properties of a dataset's metadata.
 
-See the [corresponding HTTP service documentation][134].
+See the [corresponding HTTP service documentation][129].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
-  - `config.name` **[string][111]?** 
-  - `config.description` **[string][111]?** 
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
+  - `config.name` **[string][106]?** 
+  - `config.description` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -400,12 +392,12 @@ Returns **MapiRequest**
 
 Delete a dataset, including all features it contains.
 
-See the [corresponding HTTP service documentation][135].
+See the [corresponding HTTP service documentation][130].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -416,14 +408,14 @@ List features in a dataset.
 This endpoint supports pagination. Use `MapiRequest#eachPage` or manually specify
 the `limit` and `start` options.
 
-See the [corresponding HTTP service documentation][136].
+See the [corresponding HTTP service documentation][131].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
-  - `config.limit` **[number][114]?** Only list this number of features.
-  - `config.start` **[string][111]?** The ID of the feature from which the listing should
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
+  - `config.limit` **[number][109]?** Only list this number of features.
+  - `config.start` **[string][106]?** The ID of the feature from which the listing should
       start.
 
 Returns **MapiRequest** 
@@ -432,14 +424,14 @@ Returns **MapiRequest**
 
 Add a feature to a dataset or update an existing one.
 
-See the [corresponding HTTP service documentation][137].
+See the [corresponding HTTP service documentation][132].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
-  - `config.featureId` **[string][111]** 
-  - `config.feature` **[Object][110]** Valid GeoJSON that is not a `FeatureCollection`.
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
+  - `config.featureId` **[string][106]** 
+  - `config.feature` **[Object][105]** Valid GeoJSON that is not a `FeatureCollection`.
       If the feature has a top-level `id` property, it must match the `featureId` you specify.
 
 Returns **MapiRequest** 
@@ -448,13 +440,13 @@ Returns **MapiRequest**
 
 Get a feature in a dataset.
 
-See the [corresponding HTTP service documentation][138].
+See the [corresponding HTTP service documentation][133].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
-  - `config.featureId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
+  - `config.featureId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -462,13 +454,13 @@ Returns **MapiRequest**
 
 Delete a feature in a dataset.
 
-See the [corresponding HTTP service documentation][139].
+See the [corresponding HTTP service documentation][134].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.datasetId` **[string][111]** 
-  - `config.featureId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.datasetId` **[string][106]** 
+  - `config.featureId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -477,7 +469,7 @@ Returns **MapiRequest**
 Tilequery API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][140].
+[the HTTP service documentation][135].
 
 ### listFeatures
 
@@ -485,15 +477,15 @@ List features within a radius of a point on a map (or several maps).
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.mapIds` **[Array][120]&lt;[string][111]>** The maps being queried.
+- `config` **[Object][105]** 
+  - `config.mapIds` **[Array][115]&lt;[string][106]>** The maps being queried.
       If you need to composite multiple layers, provide multiple map IDs.
-  - `config.coordinates` **[Coordinates][123]** The longitude and latitude to be queried.
-  - `config.radius` **[number][114]** The approximate distance in meters to query for features. (optional, default `0`)
-  - `config.limit` **[number][114]** The number of features to return, between 1 and 50. (optional, default `5`)
-  - `config.dedupe` **[boolean][118]** Whether or not to deduplicate results. (optional, default `true`)
+  - `config.coordinates` **[Coordinates][118]** The longitude and latitude to be queried.
+  - `config.radius` **[number][109]** The approximate distance in meters to query for features. (optional, default `0`)
+  - `config.limit` **[number][109]** The number of features to return, between 1 and 50. (optional, default `5`)
+  - `config.dedupe` **[boolean][113]** Whether or not to deduplicate results. (optional, default `true`)
   - `config.geometry` **(`"polygon"` \| `"linestring"` \| `"point"`)?** Queries for a specific geometry type.
-  - `config.layers` **[Array][120]&lt;[string][111]>?** IDs of vector layers to query.
+  - `config.layers` **[Array][115]&lt;[string][106]>?** IDs of vector layers to query.
 
 Returns **MapiRequest** 
 
@@ -502,7 +494,7 @@ Returns **MapiRequest**
 Tilesets API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][141].
+[the HTTP service documentation][136].
 
 ### listTilesets
 
@@ -510,8 +502,8 @@ List a user's tilesets.
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.ownerId` **[string][111]?** 
+- `config` **[Object][105]?** 
+  - `config.ownerId` **[string][106]?** 
 
 Returns **MapiRequest** 
 
@@ -520,29 +512,29 @@ Returns **MapiRequest**
 Geocoding API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][142].
+[the HTTP service documentation][137].
 
 ### forwardGeocode
 
 Search for a place.
 
-See the [public documentation][143].
+See the [public documentation][138].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.query` **[string][111]** A place name.
+- `config` **[Object][105]** 
+  - `config.query` **[string][106]** A place name.
   - `config.mode` **(`"mapbox.places"` \| `"mapbox.places-permanent"`)** Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding. (optional, default `"mapbox.places"`)
-  - `config.countries` **[Array][120]&lt;[string][111]>?** Limits results to the specified countries.
-      Each item in the array should be an [ISO 3166 alpha 2 country code][144].
-  - `config.proximity` **[Coordinates][123]?** Bias local results based on a provided location.
-  - `config.types` **[Array][120]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
-  - `config.autocomplete` **[boolean][118]** Return autocomplete results or not. (optional, default `true`)
-  - `config.bbox` **[BoundingBox][145]?** Limit results to a bounding box.
-  - `config.limit` **[number][114]** Limit the number of results returned. (optional, default `5`)
-  - `config.language` **[Array][120]&lt;[string][111]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
-     Options are [IETF language tags][146] comprised of a mandatory
-     [ISO 639-1 language code][147] and optionally one or more IETF subtags for country or script.
+  - `config.countries` **[Array][115]&lt;[string][106]>?** Limits results to the specified countries.
+      Each item in the array should be an [ISO 3166 alpha 2 country code][139].
+  - `config.proximity` **[Coordinates][118]?** Bias local results based on a provided location.
+  - `config.types` **[Array][115]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
+  - `config.autocomplete` **[boolean][113]** Return autocomplete results or not. (optional, default `true`)
+  - `config.bbox` **[BoundingBox][140]?** Limit results to a bounding box.
+  - `config.limit` **[number][109]** Limit the number of results returned. (optional, default `5`)
+  - `config.language` **[Array][115]&lt;[string][106]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
+     Options are [IETF language tags][141] comprised of a mandatory
+     [ISO 639-1 language code][142] and optionally one or more IETF subtags for country or script.
 
 Returns **MapiRequest** 
 
@@ -550,21 +542,21 @@ Returns **MapiRequest**
 
 Search for places near coordinates.
 
-See the [public documentation][148].
+See the [public documentation][143].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.query` **[Coordinates][123]** Coordinates at which features will be searched.
+- `config` **[Object][105]** 
+  - `config.query` **[Coordinates][118]** Coordinates at which features will be searched.
   - `config.mode` **(`"mapbox.places"` \| `"mapbox.places-permanent"`)** Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding. (optional, default `"mapbox.places"`)
-  - `config.countries` **[Array][120]&lt;[string][111]>?** Limits results to the specified countries.
-      Each item in the array should be an [ISO 3166 alpha 2 country code][144].
-  - `config.types` **[Array][120]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
-  - `config.bbox` **[BoundingBox][145]?** Limit results to a bounding box.
-  - `config.limit` **[number][114]** Limit the number of results returned. If using this option, you must provide a single item for `types`. (optional, default `1`)
-  - `config.language` **[Array][120]&lt;[string][111]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
-     Options are [IETF language tags][146] comprised of a mandatory
-     [ISO 639-1 language code][147] and optionally one or more IETF subtags for country or script.
+  - `config.countries` **[Array][115]&lt;[string][106]>?** Limits results to the specified countries.
+      Each item in the array should be an [ISO 3166 alpha 2 country code][139].
+  - `config.types` **[Array][115]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
+  - `config.bbox` **[BoundingBox][140]?** Limit results to a bounding box.
+  - `config.limit` **[number][109]** Limit the number of results returned. If using this option, you must provide a single item for `types`. (optional, default `1`)
+  - `config.language` **[Array][115]&lt;[string][106]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
+     Options are [IETF language tags][141] comprised of a mandatory
+     [ISO 639-1 language code][142] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
 
 Returns **MapiRequest** 
@@ -574,32 +566,32 @@ Returns **MapiRequest**
 Directions API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][149].
+[the HTTP service documentation][144].
 
 ### getDirections
 
 Get directions.
 
-Please read [the full HTTP service documentation][149]
+Please read [the full HTTP service documentation][144]
 to understand all of the available options.
 
 #### Parameters
 
-- `config` **[Object][110]** 
+- `config` **[Object][105]** 
   - `config.profile` **(`"driving-traffic"` \| `"driving"` \| `"walking"` \| `"cycling"`)**  (optional, default `"driving"`)
-  - `config.waypoints` **[Array][120]&lt;[DirectionsWaypoint][150]>** An ordered array of [`DirectionsWaypoint`][91] objects, between 2 and 25 (inclusive).
-  - `config.alternatives` **[boolean][118]** Whether to try to return alternative routes. (optional, default `false`)
-  - `config.annotations` **[Array][120]&lt;(`"duration"` \| `"distance"` \| `"speed"` \| `"congestion"`)>?** Specify additional metadata that should be returned.
-  - `config.bannerInstructions` **[boolean][118]** Should be used in conjunction with `steps`. (optional, default `false`)
-  - `config.continueStraight` **[boolean][118]?** Sets the allowed direction of travel when departing intermediate waypoints.
-  - `config.exclude` **[string][111]?** Exclude certain road types from routing. See HTTP service documentation for options.
+  - `config.waypoints` **[Array][115]&lt;[DirectionsWaypoint][145]>** An ordered array of [`DirectionsWaypoint`][86] objects, between 2 and 25 (inclusive).
+  - `config.alternatives` **[boolean][113]** Whether to try to return alternative routes. (optional, default `false`)
+  - `config.annotations` **[Array][115]&lt;(`"duration"` \| `"distance"` \| `"speed"` \| `"congestion"`)>?** Specify additional metadata that should be returned.
+  - `config.bannerInstructions` **[boolean][113]** Should be used in conjunction with `steps`. (optional, default `false`)
+  - `config.continueStraight` **[boolean][113]?** Sets the allowed direction of travel when departing intermediate waypoints.
+  - `config.exclude` **[string][106]?** Exclude certain road types from routing. See HTTP service documentation for options.
   - `config.geometries` **(`"geojson"` \| `"polyline"` \| `"polyline6"`)** Format of the returned geometry. (optional, default `"polyline"`)
-  - `config.language` **[string][111]** Language of returned turn-by-turn text instructions.
-      See options listed in [the HTTP service documentation][151]. (optional, default `"en"`)
+  - `config.language` **[string][106]** Language of returned turn-by-turn text instructions.
+      See options listed in [the HTTP service documentation][146]. (optional, default `"en"`)
   - `config.overview` **(`"simplified"` \| `"full"` \| `"false"`)** Type of returned overview geometry. (optional, default `"simplified"`)
-  - `config.roundaboutExits` **[boolean][118]** Emit insbtructions at roundabout exits. (optional, default `false`)
-  - `config.steps` **[boolean][118]** Whether to return steps and turn-by-turn instructions. (optional, default `false`)
-  - `config.voiceInstructions` **[boolean][118]** Whether or not to return SSML marked-up text for voice guidance along the route. (optional, default `false`)
+  - `config.roundaboutExits` **[boolean][113]** Emit insbtructions at roundabout exits. (optional, default `false`)
+  - `config.steps` **[boolean][113]** Whether to return steps and turn-by-turn instructions. (optional, default `false`)
+  - `config.voiceInstructions` **[boolean][113]** Whether or not to return SSML marked-up text for voice guidance along the route. (optional, default `false`)
   - `config.voiceUnits` **(`"imperial"` \| `"metric"`)** Which type of units to return in the text for voice instructions. (optional, default `"imperial"`)
 
 Returns **MapiRequest** 
@@ -609,7 +601,7 @@ Returns **MapiRequest**
 Map Matching API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][152].
+[the HTTP service documentation][147].
 
 ### getMatching
 
@@ -617,16 +609,16 @@ Snap recorded location traces to roads and paths.
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.points` **[Array][120]&lt;[MapMatchingPoint][153]>** An ordered array of [`MapMatchingPoint`][93]s, between 2 and 100 (inclusive).
+- `config` **[Object][105]** 
+  - `config.points` **[Array][115]&lt;[MapMatchingPoint][148]>** An ordered array of [`MapMatchingPoint`][88]s, between 2 and 100 (inclusive).
   - `config.profile` **(`"driving-traffic"` \| `"driving"` \| `"walking"` \| `"cycling"`)** A directions profile ID. (optional, default `driving`)
-  - `config.annotations` **[Array][120]&lt;(`"duration"` \| `"distance"` \| `"speed"`)>?** Specify additional metadata that should be returned.
+  - `config.annotations` **[Array][115]&lt;(`"duration"` \| `"distance"` \| `"speed"`)>?** Specify additional metadata that should be returned.
   - `config.geometries` **(`"geojson"` \| `"polyline"` \| `"polyline6"`)** Format of the returned geometry. (optional, default `"polyline"`)
-  - `config.language` **[string][111]** Language of returned turn-by-turn text instructions.
-      See [supported languages][151]. (optional, default `"en"`)
+  - `config.language` **[string][106]** Language of returned turn-by-turn text instructions.
+      See [supported languages][146]. (optional, default `"en"`)
   - `config.overview` **(`"simplified"` \| `"full"` \| `"false"`)** Type of returned overview geometry. (optional, default `"simplified"`)
-  - `config.steps` **[boolean][118]** Whether to return steps and turn-by-turn instructions. (optional, default `false`)
-  - `config.tidy` **[boolean][118]** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default `false`)
+  - `config.steps` **[boolean][113]** Whether to return steps and turn-by-turn instructions. (optional, default `false`)
+  - `config.tidy` **[boolean][113]** Whether or not to transparently remove clusters and re-sample traces for improved map matching results. (optional, default `false`)
 
 Returns **MapiRequest** 
 
@@ -635,7 +627,7 @@ Returns **MapiRequest**
 Map Matching API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][154].
+[the HTTP service documentation][149].
 
 ### getMatrix
 
@@ -643,12 +635,12 @@ Get a duration and/or distance matrix showing travel times and distances between
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.points` **[Array][120]&lt;[MatrixPoint][155]>** An ordered array of [`MatrixPoint`][95]s, between 2 and 100 (inclusive).
+- `config` **[Object][105]** 
+  - `config.points` **[Array][115]&lt;[MatrixPoint][150]>** An ordered array of [`MatrixPoint`][90]s, between 2 and 100 (inclusive).
   - `config.profile` **(`"driving-traffic"` \| `"driving"` \| `"walking"` \| `"cycling"`)** A Mapbox Directions routing profile ID. (optional, default `driving`)
-  - `config.sources` **(`"all"` \| [Array][120]&lt;[number][114]>)?** Use coordinates with given index as sources.
-  - `config.destinations` **(`"all"` \| [Array][120]&lt;[number][114]>)?** Use coordinates with given index as destinations.
-  - `config.annotations` **[Array][120]&lt;(`"distance"` \| `"duration"`)>?** Used to specify resulting matrices.
+  - `config.sources` **(`"all"` \| [Array][115]&lt;[number][109]>)?** Use coordinates with given index as sources.
+  - `config.destinations` **(`"all"` \| [Array][115]&lt;[number][109]>)?** Use coordinates with given index as destinations.
+  - `config.annotations` **[Array][115]&lt;(`"distance"` \| `"duration"`)>?** Used to specify resulting matrices.
 
 Returns **MapiRequest** 
 
@@ -657,17 +649,13 @@ Returns **MapiRequest**
 Tokens API service.
 
 Learn more about this service and its responses in
-[the HTTP service documentation][156].
+[the HTTP service documentation][151].
 
 ### listTokens
 
 List your access tokens.
 
-See the [corresponding HTTP service documentation][157].
-
-#### Parameters
-
-- `config`  
+See the [corresponding HTTP service documentation][152].
 
 Returns **MapiRequest** 
 
@@ -675,14 +663,14 @@ Returns **MapiRequest**
 
 Create a new access token.
 
-See the [corresponding HTTP service documentation][158].
+See the [corresponding HTTP service documentation][153].
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.note` **[string][111]?** 
-  - `config.scopes` **[Array][120]&lt;[string][111]>?** 
-  - `config.resources` **[Array][120]&lt;[string][111]>?** 
+- `config` **[Object][105]?** 
+  - `config.note` **[string][106]?** 
+  - `config.scopes` **[Array][115]&lt;[string][106]>?** 
+  - `config.resources` **[Array][115]&lt;[string][106]>?** 
 
 Returns **MapiRequest** 
 
@@ -690,13 +678,13 @@ Returns **MapiRequest**
 
 Create a new temporary access token.
 
-See the [corresponding HTTP service documentation][159].
+See the [corresponding HTTP service documentation][154].
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.expires` **[string][111]?** 
-  - `config.scopes` **[Array][120]&lt;[string][111]>?** 
+- `config` **[Object][105]?** 
+  - `config.expires` **[string][106]?** 
+  - `config.scopes` **[Array][115]&lt;[string][106]>?** 
 
 Returns **MapiRequest** 
 
@@ -704,15 +692,15 @@ Returns **MapiRequest**
 
 Update an access token.
 
-See the [corresponding HTTP service documentation][160].
+See the [corresponding HTTP service documentation][155].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.tokenId` **[string][111]** 
-  - `config.note` **[string][111]?** 
-  - `config.scopes` **[Array][120]&lt;[string][111]>?** 
-  - `config.resources` **[Array][120]&lt;[string][111]>?** 
+- `config` **[Object][105]** 
+  - `config.tokenId` **[string][106]** 
+  - `config.note` **[string][106]?** 
+  - `config.scopes` **[Array][115]&lt;[string][106]>?** 
+  - `config.resources` **[Array][115]&lt;[string][106]>?** 
 
 Returns **MapiRequest** 
 
@@ -720,11 +708,7 @@ Returns **MapiRequest**
 
 Get data about the client's access token.
 
-See the [corresponding HTTP service documentation][161].
-
-#### Parameters
-
-- `config`  
+See the [corresponding HTTP service documentation][156].
 
 Returns **MapiRequest** 
 
@@ -732,12 +716,12 @@ Returns **MapiRequest**
 
 Delete an access token.
 
-See the [corresponding HTTP service documentation][162].
+See the [corresponding HTTP service documentation][157].
 
 #### Parameters
 
-- `config` **[Object][110]** 
-  - `config.tokenId` **[string][111]** 
+- `config` **[Object][105]** 
+  - `config.tokenId` **[string][106]** 
 
 Returns **MapiRequest** 
 
@@ -746,11 +730,7 @@ Returns **MapiRequest**
 List your available scopes. Each item is a metadata
 object about the scope, not just the string scope.
 
-See the [corresponding HTTP service documentation][163].
-
-#### Parameters
-
-- `config`  
+See the [corresponding HTTP service documentation][158].
 
 Returns **MapiRequest** 
 
@@ -760,114 +740,114 @@ Data structures used in service method configuration.
 
 ### DirectionsWaypoint
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `coordinates` **[Coordinates][123]** 
+- `coordinates` **[Coordinates][118]** 
 - `approach` **(`"unrestricted"` \| `"curb"`)?** Used to indicate how requested routes consider from which side of the road to approach the waypoint.
-- `bearing` **\[[number][114], [number][114]]?** Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
+- `bearing` **\[[number][109], [number][109]]?** Used to filter the road segment the waypoint will be placed on by direction and dictates the angle of approach.
     This option should always be used in conjunction with a `radius`. The first value is an angle clockwise from true north between 0 and 360,
     and the second is the range of degrees the angle can deviate by.
-- `radius` **([number][114] \| `"unlimited"`)?** Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment.
-- `waypointName` **[string][111]?** Custom name for the waypoint used for the arrival instruction in banners and voice instructions.
+- `radius` **([number][109] \| `"unlimited"`)?** Maximum distance in meters that the coordinate is allowed to move when snapped to a nearby road segment.
+- `waypointName` **[string][106]?** Custom name for the waypoint used for the arrival instruction in banners and voice instructions.
 
 ### MapMatchingPoint
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `coordinates` **[Coordinates][123]** 
+- `coordinates` **[Coordinates][118]** 
 - `approach` **(`"unrestricted"` \| `"curb"`)?** Used to indicate how requested routes consider from which side of the road to approach a waypoint.
-- `radius` **[number][114]?** A number in meters indicating the assumed precision of the used tracking device.
-- `isWaypoint` **[boolean][118]?** Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints.
-- `waypointName` **[string][111]?** Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless `isWaypoint` is `true`.
-- `timestamp` **(tring | [number][114] \| [Date][115])?** Datetime corresponding to the coordinate.
+- `radius` **[number][109]?** A number in meters indicating the assumed precision of the used tracking device.
+- `isWaypoint` **[boolean][113]?** Whether this coordinate is waypoint or not. The first and last coordinates will always be waypoints.
+- `waypointName` **[string][106]?** Custom name for the waypoint used for the arrival instruction in banners and voice instructions. Will be ignored unless `isWaypoint` is `true`.
+- `timestamp` **(tring | [number][109] \| [Date][110])?** Datetime corresponding to the coordinate.
 
 ### MatrixPoint
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `coordinates` **[Coordinates][123]** `[longitude, latitude]`
+- `coordinates` **[Coordinates][118]** `[longitude, latitude]`
 - `approach` **(`"unrestricted"` \| `"curb"`)?** Used to indicate how requested routes consider from which side of the road to approach the point.
 
 ### SimpleMarkerOverlay
 
 A simple marker overlay.
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `marker` **[Object][110]** 
-  - `marker.coordinates` **\[[number][114], [number][114]]** `[longitude, latitude]`
+- `marker` **[Object][105]** 
+  - `marker.coordinates` **\[[number][109], [number][109]]** `[longitude, latitude]`
   - `marker.size` **(`"large"` \| `"small"`)?** 
-  - `marker.label` **[string][111]?** Marker symbol. Options are an alphanumeric label `a`
-      through `z`, `0` through `99`, or a valid [Maki][164]
+  - `marker.label` **[string][106]?** Marker symbol. Options are an alphanumeric label `a`
+      through `z`, `0` through `99`, or a valid [Maki][159]
       icon. If a letter is requested, it will be rendered in uppercase only.
-  - `marker.color` **[string][111]?** A 3- or 6-digit hexadecimal color code.
+  - `marker.color` **[string][106]?** A 3- or 6-digit hexadecimal color code.
 
 ### CustomMarkerOverlay
 
 A marker overlay with a custom image.
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `marker` **[Object][110]** 
-  - `marker.coordinates` **\[[number][114], [number][114]]** `[longitude, latitude]`
-  - `marker.url` **[string][111]** 
+- `marker` **[Object][105]** 
+  - `marker.coordinates` **\[[number][109], [number][109]]** `[longitude, latitude]`
+  - `marker.url` **[string][106]** 
 
 ### PathOverlay
 
 A stylable line.
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `path` **[Object][110]** 
-  - `path.coordinates` **[Array][120]&lt;\[[number][114], [number][114]]>** An array of coordinates
+- `path` **[Object][105]** 
+  - `path.coordinates` **[Array][115]&lt;\[[number][109], [number][109]]>** An array of coordinates
       describing the path.
-  - `path.strokeWidth` **[number][114]?** 
-  - `path.strokeColor` **[string][111]?** 
-  - `path.strokeOpacity` **[number][114]?** Must be paired with strokeColor.
-  - `path.fillColor` **[string][111]?** Must be paired with strokeColor.
-  - `path.fillOpacity` **[number][114]?** Must be paired with fillColor.
+  - `path.strokeWidth` **[number][109]?** 
+  - `path.strokeColor` **[string][106]?** 
+  - `path.strokeOpacity` **[number][109]?** Must be paired with strokeColor.
+  - `path.fillColor` **[string][106]?** Must be paired with strokeColor.
+  - `path.fillOpacity` **[number][109]?** Must be paired with fillColor.
 
 ### GeoJsonOverlay
 
 GeoJSON to overlay the map.
 
-Type: [Object][110]
+Type: [Object][105]
 
 #### Properties
 
-- `geoJson` **[Object][110]** Valid GeoJSON.
+- `geoJson` **[Object][105]** Valid GeoJSON.
 
-### Coordinates
-
-`[longitude, latitude]`
-
-Type: [Array][120]&lt;[number][114]>
-
-### BoundingBox
-
-`[minLongitude, minLatitude, maxLongitude, maxLatitude]`
-
-Type: [Array][120]&lt;[number][114]>
-
-## UploadableFile
+### UploadableFile
 
 In Node, files must be `ReadableStream`s or paths pointing for the file in the filesystem.
 
 In the browser, files must be `Blob`s or `ArrayBuffer`s.
 
-Type: ([Blob][165] \| [ArrayBuffer][166] \| [string][111] | ReadableStream)
+Type: ([Blob][160] \| [ArrayBuffer][161] \| [string][106] | ReadableStream)
+
+### Coordinates
+
+`[longitude, latitude]`
+
+Type: [Array][115]&lt;[number][109]>
+
+### BoundingBox
+
+`[minLongitude, minLatitude, maxLongitude, maxLatitude]`
+
+Type: [Array][115]&lt;[number][109]>
 
 [1]: #styles
 
@@ -925,278 +905,268 @@ Type: ([Blob][165] \| [ArrayBuffer][166] \| [string][111] | ReadableStream)
 
 [28]: #createuploadcredentials
 
-[29]: #parameters-12
+[29]: #createupload
 
-[30]: #createupload
+[30]: #parameters-12
 
-[31]: #parameters-13
+[31]: #getupload
 
-[32]: #getupload
+[32]: #parameters-13
 
-[33]: #parameters-14
+[33]: #deleteupload
 
-[34]: #deleteupload
+[34]: #parameters-14
 
-[35]: #parameters-15
+[35]: #datasets
 
-[36]: #datasets
+[36]: #listdatasets
 
-[37]: #listdatasets
+[37]: #createdataset
 
-[38]: #parameters-16
+[38]: #parameters-15
 
-[39]: #createdataset
+[39]: #getmetadata
 
-[40]: #parameters-17
+[40]: #parameters-16
 
-[41]: #getmetadata
+[41]: #updatemetadata
 
-[42]: #parameters-18
+[42]: #parameters-17
 
-[43]: #updatemetadata
+[43]: #deletedataset
 
-[44]: #parameters-19
+[44]: #parameters-18
 
-[45]: #deletedataset
+[45]: #listfeatures
 
-[46]: #parameters-20
+[46]: #parameters-19
 
-[47]: #listfeatures
+[47]: #putfeature
 
-[48]: #parameters-21
+[48]: #parameters-20
 
-[49]: #putfeature
+[49]: #getfeature
 
-[50]: #parameters-22
+[50]: #parameters-21
 
-[51]: #getfeature
+[51]: #deletefeature
 
-[52]: #parameters-23
+[52]: #parameters-22
 
-[53]: #deletefeature
+[53]: #tilequery
 
-[54]: #parameters-24
+[54]: #listfeatures-1
 
-[55]: #tilequery
+[55]: #parameters-23
 
-[56]: #listfeatures-1
+[56]: #tilesets
 
-[57]: #parameters-25
+[57]: #listtilesets
 
-[58]: #tilesets
+[58]: #parameters-24
 
-[59]: #listtilesets
+[59]: #geocoding
 
-[60]: #parameters-26
+[60]: #forwardgeocode
 
-[61]: #geocoding
+[61]: #parameters-25
 
-[62]: #forwardgeocode
+[62]: #reversegeocode
 
-[63]: #parameters-27
+[63]: #parameters-26
 
-[64]: #reversegeocode
+[64]: #directions
 
-[65]: #parameters-28
+[65]: #getdirections
 
-[66]: #directions
+[66]: #parameters-27
 
-[67]: #getdirections
+[67]: #mapmatching
 
-[68]: #parameters-29
+[68]: #getmatching
 
-[69]: #mapmatching
+[69]: #parameters-28
 
-[70]: #getmatching
+[70]: #matrix
 
-[71]: #parameters-30
+[71]: #getmatrix
 
-[72]: #matrix
+[72]: #parameters-29
 
-[73]: #getmatrix
+[73]: #tokens
 
-[74]: #parameters-31
+[74]: #listtokens
 
-[75]: #tokens
+[75]: #createtoken
 
-[76]: #listtokens
+[76]: #parameters-30
 
-[77]: #parameters-32
+[77]: #createtemporarytoken
 
-[78]: #createtoken
+[78]: #parameters-31
 
-[79]: #parameters-33
+[79]: #updatetoken
 
-[80]: #createtemporarytoken
+[80]: #parameters-32
 
-[81]: #parameters-34
+[81]: #gettoken
 
-[82]: #updatetoken
+[82]: #deletetoken
 
-[83]: #parameters-35
+[83]: #parameters-33
 
-[84]: #gettoken
+[84]: #listscopes
 
-[85]: #parameters-36
+[85]: #data-structures
 
-[86]: #deletetoken
+[86]: #directionswaypoint
 
-[87]: #parameters-37
+[87]: #properties
 
-[88]: #listscopes
+[88]: #mapmatchingpoint
 
-[89]: #parameters-38
+[89]: #properties-1
 
-[90]: #data-structures
+[90]: #matrixpoint
 
-[91]: #directionswaypoint
+[91]: #properties-2
 
-[92]: #properties
+[92]: #simplemarkeroverlay
 
-[93]: #mapmatchingpoint
+[93]: #properties-3
 
-[94]: #properties-1
+[94]: #custommarkeroverlay
 
-[95]: #matrixpoint
+[95]: #properties-4
 
-[96]: #properties-2
+[96]: #pathoverlay
 
-[97]: #simplemarkeroverlay
+[97]: #properties-5
 
-[98]: #properties-3
+[98]: #geojsonoverlay
 
-[99]: #custommarkeroverlay
+[99]: #properties-6
 
-[100]: #properties-4
+[100]: #uploadablefile
 
-[101]: #pathoverlay
+[101]: #coordinates
 
-[102]: #properties-5
+[102]: #boundingbox
 
-[103]: #geojsonoverlay
+[103]: https://www.mapbox.com/api-documentation/#styles
 
-[104]: #properties-6
+[104]: https://www.mapbox.com/api-documentation/#retrieve-a-style
 
-[105]: #coordinates
+[105]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[106]: #boundingbox
+[106]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[107]: #uploadablefile
+[107]: https://www.mapbox.com/api-documentation/#create-a-style
 
-[108]: https://www.mapbox.com/api-documentation/#styles
+[108]: https://www.mapbox.com/api-documentation/#update-a-style
 
-[109]: https://www.mapbox.com/api-documentation/#retrieve-a-style
+[109]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[110]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[110]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
 
-[111]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[111]: #uploadablefile
 
-[112]: https://www.mapbox.com/api-documentation/#create-a-style
+[112]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-a-sprite-image-or-json
 
-[113]: https://www.mapbox.com/api-documentation/#update-a-style
+[113]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[114]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[114]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-font-glyph-ranges
 
-[115]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date
+[115]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
-[116]: #uploadablefile
+[116]: https://www.mapbox.com/api-documentation/?language=JavaScript#embed-a-style
 
-[117]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-a-sprite-image-or-json
+[117]: https://www.mapbox.com/api-documentation/#static
 
-[118]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+[118]: #coordinates
 
-[119]: https://www.mapbox.com/api-documentation/?language=JavaScript#retrieve-font-glyph-ranges
+[119]: https://www.mapbox.com/api-documentation/#uploads
 
-[120]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+[120]: https://www.mapbox.com/api-documentation/#retrieve-recent-upload-statuses
 
-[121]: https://www.mapbox.com/api-documentation/?language=JavaScript#embed-a-style
+[121]: https://www.mapbox.com/api-documentation/#retrieve-s3-credentials
 
-[122]: https://www.mapbox.com/api-documentation/#static
+[122]: https://www.mapbox.com/api-documentation/#create-an-upload
 
-[123]: #coordinates
+[123]: https://www.mapbox.com/api-documentation/#retrieve-upload-status
 
-[124]: https://www.mapbox.com/api-documentation/#uploads
+[124]: https://www.mapbox.com/api-documentation/#remove-an-upload
 
-[125]: https://www.mapbox.com/api-documentation/#retrieve-recent-upload-statuses
+[125]: https://www.mapbox.com/api-documentation/#datasets
 
-[126]: https://www.mapbox.com/api-documentation/#retrieve-s3-credentials
+[126]: https://www.mapbox.com/api-documentation/#list-datasets
 
-[127]: https://www.mapbox.com/api-documentation/#create-an-upload
+[127]: https://www.mapbox.com/api-documentation/#create-dataset
 
-[128]: https://www.mapbox.com/api-documentation/#retrieve-upload-status
+[128]: https://www.mapbox.com/api-documentation/#retrieve-a-dataset
 
-[129]: https://www.mapbox.com/api-documentation/#remove-an-upload
+[129]: https://www.mapbox.com/api-documentation/#update-a-dataset
 
-[130]: https://www.mapbox.com/api-documentation/#datasets
+[130]: https://www.mapbox.com/api-documentation/#delete-a-dataset
 
-[131]: https://www.mapbox.com/api-documentation/#list-datasets
+[131]: https://www.mapbox.com/api-documentation/#list-features
 
-[132]: https://www.mapbox.com/api-documentation/#create-dataset
+[132]: https://www.mapbox.com/api-documentation/#insert-or-update-a-feature
 
-[133]: https://www.mapbox.com/api-documentation/#retrieve-a-dataset
+[133]: https://www.mapbox.com/api-documentation/#retrieve-a-feature
 
-[134]: https://www.mapbox.com/api-documentation/#update-a-dataset
+[134]: https://www.mapbox.com/api-documentation/#delete-a-feature
 
-[135]: https://www.mapbox.com/api-documentation/#delete-a-dataset
+[135]: https://www.mapbox.com/api-documentation/#tilequery
 
-[136]: https://www.mapbox.com/api-documentation/#list-features
+[136]: https://www.mapbox.com/api-documentation/#tilesets
 
-[137]: https://www.mapbox.com/api-documentation/#insert-or-update-a-feature
+[137]: https://www.mapbox.com/api-documentation/#geocoding
 
-[138]: https://www.mapbox.com/api-documentation/#retrieve-a-feature
+[138]: https://www.mapbox.com/api-documentation/#search-for-places
 
-[139]: https://www.mapbox.com/api-documentation/#delete-a-feature
+[139]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 
-[140]: https://www.mapbox.com/api-documentation/#tilequery
+[140]: #boundingbox
 
-[141]: https://www.mapbox.com/api-documentation/#tilesets
+[141]: https://en.wikipedia.org/wiki/IETF_language_tag
 
-[142]: https://www.mapbox.com/api-documentation/#geocoding
+[142]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 
-[143]: https://www.mapbox.com/api-documentation/#search-for-places
+[143]: https://www.mapbox.com/api-documentation/#retrieve-places-near-a-location
 
-[144]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[144]: https://www.mapbox.com/api-documentation/#directions
 
-[145]: #boundingbox
+[145]: #directionswaypoint
 
-[146]: https://en.wikipedia.org/wiki/IETF_language_tag
+[146]: https://www.mapbox.com/api-documentation/#instructions-languages
 
-[147]: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+[147]: https://www.mapbox.com/api-documentation/#map-matching
 
-[148]: https://www.mapbox.com/api-documentation/#retrieve-places-near-a-location
+[148]: #mapmatchingpoint
 
-[149]: https://www.mapbox.com/api-documentation/#directions
+[149]: https://www.mapbox.com/api-documentation/#matrix
 
-[150]: #directionswaypoint
+[150]: #matrixpoint
 
-[151]: https://www.mapbox.com/api-documentation/#instructions-languages
+[151]: https://www.mapbox.com/api-documentation/#tokens
 
-[152]: https://www.mapbox.com/api-documentation/#map-matching
+[152]: https://www.mapbox.com/api-documentation/#list-tokens
 
-[153]: #mapmatchingpoint
+[153]: https://www.mapbox.com/api-documentation/#create-token
 
-[154]: https://www.mapbox.com/api-documentation/#matrix
+[154]: https://www.mapbox.com/api-documentation/#create-temporary-token
 
-[155]: #matrixpoint
+[155]: https://www.mapbox.com/api-documentation/#update-a-token
 
-[156]: https://www.mapbox.com/api-documentation/#tokens
+[156]: https://www.mapbox.com/api-documentation/#retrieve-a-token
 
-[157]: https://www.mapbox.com/api-documentation/#list-tokens
+[157]: https://www.mapbox.com/api-documentation/?language=cURL#delete-a-token
 
-[158]: https://www.mapbox.com/api-documentation/#create-token
+[158]: https://www.mapbox.com/api-documentation/#list-scopes
 
-[159]: https://www.mapbox.com/api-documentation/#create-temporary-token
+[159]: https://www.mapbox.com/maki/
 
-[160]: https://www.mapbox.com/api-documentation/#update-a-token
+[160]: https://developer.mozilla.org/docs/Web/API/Blob
 
-[161]: https://www.mapbox.com/api-documentation/#retrieve-a-token
-
-[162]: https://www.mapbox.com/api-documentation/?language=cURL#delete-a-token
-
-[163]: https://www.mapbox.com/api-documentation/#list-scopes
-
-[164]: https://www.mapbox.com/maki/
-
-[165]: https://developer.mozilla.org/docs/Web/API/Blob
-
-[166]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+[161]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer

--- a/services/__tests__/tokens.test.js
+++ b/services/__tests__/tokens.test.js
@@ -17,15 +17,6 @@ describe('listTokens', () => {
       params: undefined
     });
   });
-
-  test('works with specified ownerId', () => {
-    tokens.listTokens({ ownerId: 'specialguy' });
-    expect(tu.requestConfig(tokens)).toEqual({
-      path: '/tokens/v2/:ownerId',
-      params: { ownerId: 'specialguy' },
-      method: 'GET'
-    });
-  });
 });
 
 describe('createToken', () => {
@@ -52,14 +43,13 @@ describe('createToken', () => {
   test('with all options', () => {
     tokens.createToken({
       scopes: ['styles:list'],
-      ownerId: 'chickentooth',
       note: 'horseleg',
       resources: ['one', 'two']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId',
-      params: { ownerId: 'chickentooth' },
       method: 'POST',
+      params: {},
       body: {
         scopes: ['styles:list'],
         note: 'horseleg',

--- a/services/datasets.js
+++ b/services/datasets.js
@@ -19,9 +19,7 @@ var Datasets = {};
  *
  * @return {MapiRequest}
  */
-Datasets.listDatasets = function(config) {
-  v.assertShape({})(config);
-
+Datasets.listDatasets = function() {
   return this.client.createRequest({
     method: 'GET',
     path: '/datasets/v1/:ownerId'

--- a/services/tokens.js
+++ b/services/tokens.js
@@ -19,13 +19,10 @@ var Tokens = {};
  *
  * @return {MapiRequest}
  */
-Tokens.listTokens = function(config) {
-  v.assertShape({})(config);
-
+Tokens.listTokens = function() {
   return this.client.createRequest({
     method: 'GET',
-    path: '/tokens/v2/:ownerId',
-    params: config
+    path: '/tokens/v2/:ownerId'
   });
 };
 
@@ -139,9 +136,7 @@ Tokens.updateToken = function(config) {
  *
  * @return {MapiRequest}
  */
-Tokens.getToken = function(config) {
-  v.assertShape({})(config);
-
+Tokens.getToken = function() {
   return this.client.createRequest({
     method: 'GET',
     path: '/tokens/v2'
@@ -177,13 +172,10 @@ Tokens.deleteToken = function(config) {
  *
  * @return {MapiRequest}
  */
-Tokens.listScopes = function(config) {
-  v.assertShape({})(config);
-
+Tokens.listScopes = function() {
   return this.client.createRequest({
     method: 'GET',
-    path: '/scopes/v1/:ownerId',
-    params: config
+    path: '/scopes/v1/:ownerId'
   });
 };
 

--- a/services/uploads.js
+++ b/services/uploads.js
@@ -39,9 +39,7 @@ Uploads.listUploads = function(config) {
  *
  * @return {MapiRequest}
  */
-Uploads.createUploadCredentials = function(config) {
-  v.assertShape({})(config);
-
+Uploads.createUploadCredentials = function() {
   return this.client.createRequest({
     method: 'POST',
     path: '/uploads/v1/:ownerId/credentials'


### PR DESCRIPTION
Because we won't currently throw validation errors if unnecessary props are provided (https://github.com/mapbox/mapbox-sdk-js/issues/239), we can just remove the validation step from these methods.

@kepta for review.