### PR TITLE
Fix Uploads#createUpload and allow for dataset IDs

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -283,7 +283,7 @@ Returns **MapiRequest**
 
 ### createUploadCredentials
 
-Create s3 credentials.
+Create S3 credentials.
 
 See the [corresponding HTTP service documentation][121].
 
@@ -300,7 +300,9 @@ See the [corresponding HTTP service documentation][122].
 - `config` **[Object][105]** 
   - `config.mapId` **[string][106]** The map ID to create or replace in the format `username.nameoftileset`.
       Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
-  - `config.s3Url` **[string][106]** HTTPS URL of the S3 object provided in the credential request or the dataset ID of an existing Mapbox dataset to be uploaded.
+  - `config.url` **[string][106]** Either of the following:-   HTTPS URL of the S3 object provided by [`createUploadCredentials`][28]
+    - The `mapbox://` URL of an existing dataset that you'd like to export to a tileset.
+      This should be in the format `mapbox://datasets/{username}/{datasetId}`.
   - `config.tilesetName` **[string][106]?** Name for the tileset. Limited to 64 characters.
 
 Returns **MapiRequest** 

--- a/services/__tests__/uploads.test.js
+++ b/services/__tests__/uploads.test.js
@@ -34,16 +34,16 @@ describe('createUpload', () => {
   test('works', () => {
     uploads.createUpload({
       mapId: 'tilted_towers',
-      s3Url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
+      url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
       tilesetName: 'dusty_devote'
     });
     expect(tu.requestConfig(uploads)).toEqual({
       path: '/uploads/v1/:ownerId',
       method: 'POST',
       body: {
-        mapId: 'tilted_towers',
-        s3Url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
-        tilesetName: 'dusty_devote'
+        tileset: 'tilted_towers',
+        url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
+        name: 'dusty_devote'
       }
     });
   });

--- a/services/uploads.js
+++ b/services/uploads.js
@@ -33,7 +33,7 @@ Uploads.listUploads = function(config) {
 };
 
 /**
- * Create s3 credentials.
+ * Create S3 credentials.
  *
  * See the [corresponding HTTP service documentation](https://www.mapbox.com/api-documentation/#retrieve-s3-credentials).
  *
@@ -54,21 +54,28 @@ Uploads.createUploadCredentials = function() {
  * @param {Object} config
  * @param {string} config.mapId - The map ID to create or replace in the format `username.nameoftileset`.
  *   Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
- * @param {string} config.s3Url - HTTPS URL of the S3 object provided in the credential request or the dataset ID of an existing Mapbox dataset to be uploaded.
+ * @param {string} config.url - Either of the following:
+ *   - HTTPS URL of the S3 object provided by [`createUploadCredentials`](#createuploadcredentials)
+ *   - The `mapbox://` URL of an existing dataset that you'd like to export to a tileset.
+ *     This should be in the format `mapbox://datasets/{username}/{datasetId}`.
  * @param {string} [config.tilesetName] - Name for the tileset. Limited to 64 characters.
  * @return {MapiRequest}
  */
 Uploads.createUpload = function(config) {
   v.assertShape({
     mapId: v.required(v.string),
-    s3Url: v.required(v.string),
+    url: v.required(v.string),
     tilesetName: v.string
   })(config);
 
   return this.client.createRequest({
     method: 'POST',
     path: '/uploads/v1/:ownerId',
-    body: config
+    body: {
+      tileset: config.mapId,
+      url: config.url,
+      name: config.tilesetName
+    }
   });
 };
 


### PR DESCRIPTION
I think that the body being sent for `createUpload` was sending the wrong properties. I also adjusted the `s3Url` option so it could more clearly be used for dataset exports, which will allow us to wrap up https://github.com/mapbox/mapbox-sdk-js/issues/125 as part of the revitalization.

I verified that I was able to create a dataset upload after the changes.

@kepta for review.