### PR TITLE
Stringify more boolean values passed to query string

### DIFF
--- a/services/__tests__/directions.test.js
+++ b/services/__tests__/directions.test.js
@@ -53,7 +53,7 @@ describe('getDirections', () => {
         profile: 'walking'
       },
       query: {
-        alternatives: false,
+        alternatives: 'false',
         geometries: 'polyline'
       }
     });
@@ -85,8 +85,8 @@ describe('getDirections', () => {
         profile: 'walking'
       },
       query: {
-        steps: false,
-        continue_straight: false,
+        steps: 'false',
+        continue_straight: 'false',
         radiuses: '2000;2000',
         bearings: '45,20;46,21'
       }
@@ -122,8 +122,8 @@ describe('getDirections', () => {
         profile: 'walking'
       },
       query: {
-        steps: false,
-        continue_straight: false,
+        steps: 'false',
+        continue_straight: 'false',
         bearings: ';;45,32;'
       }
     });
@@ -159,8 +159,8 @@ describe('getDirections', () => {
         profile: 'walking'
       },
       query: {
-        steps: false,
-        continue_straight: false,
+        steps: 'false',
+        continue_straight: 'false',
         bearings: ';;45,32;',
         radiuses: '2000;;;'
       }

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -48,7 +48,7 @@ describe('forwardGeocode', () => {
         country: ['AO', 'AR'],
         proximity: [3, 4],
         types: ['country', 'region'],
-        autocomplete: true,
+        autocomplete: 'true',
         bbox: [1, 2, 3, 4],
         limit: 3,
         language: ['de', 'bs']

--- a/services/directions.js
+++ b/services/directions.js
@@ -3,6 +3,7 @@
 var v = require('./service-helpers/validator');
 var createServiceFactory = require('./service-helpers/create-service-factory');
 var objectClean = require('./service-helpers/object-clean');
+var stringifyBooleans = require('./service-helpers/stringify-booleans');
 
 /**
  * Directions API service.
@@ -127,7 +128,7 @@ Directions.getDirections = function(config) {
     }
   });
 
-  var query = {
+  var query = stringifyBooleans({
     alternatives: config.alternatives,
     annotations: config.annotations,
     banner_instructions: config.bannerInstructions,
@@ -144,7 +145,7 @@ Directions.getDirections = function(config) {
     bearings: path.bearing,
     radiuses: path.radius,
     waypoint_names: path.waypointName
-  };
+  });
 
   return this.client.createRequest({
     method: 'GET',

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -3,6 +3,7 @@
 var xtend = require('xtend');
 var v = require('./service-helpers/validator');
 var pick = require('./service-helpers/pick');
+var stringifyBooleans = require('./service-helpers/stringify-booleans');
 var createServiceFactory = require('./service-helpers/create-service-factory');
 
 /**
@@ -61,11 +62,8 @@ Geocoding.forwardGeocode = function(config) {
 
   config.mode = config.mode || 'mapbox.places';
 
-  return this.client.createRequest({
-    method: 'GET',
-    path: '/geocoding/v5/:mode/:query.json',
-    params: pick(config, ['mode', 'query']),
-    query: xtend(
+  var query = stringifyBooleans(
+    xtend(
       { country: config.countries },
       pick(config, [
         'proximity',
@@ -76,6 +74,13 @@ Geocoding.forwardGeocode = function(config) {
         'language'
       ])
     )
+  );
+
+  return this.client.createRequest({
+    method: 'GET',
+    path: '/geocoding/v5/:mode/:query.json',
+    params: pick(config, ['mode', 'query']),
+    query: query
   });
 };
 
@@ -112,11 +117,8 @@ Geocoding.reverseGeocode = function(config) {
 
   config.mode = config.mode || 'mapbox.places';
 
-  return this.client.createRequest({
-    method: 'GET',
-    path: '/geocoding/v5/:mode/:query.json',
-    params: pick(config, ['mode', 'query']),
-    query: xtend(
+  var query = stringifyBooleans(
+    xtend(
       { country: config.countries },
       pick(config, [
         'country',
@@ -127,6 +129,13 @@ Geocoding.reverseGeocode = function(config) {
         'reverseMode'
       ])
     )
+  );
+
+  return this.client.createRequest({
+    method: 'GET',
+    path: '/geocoding/v5/:mode/:query.json',
+    params: pick(config, ['mode', 'query']),
+    query: query
   });
 };
 

--- a/services/map-matching.js
+++ b/services/map-matching.js
@@ -2,9 +2,9 @@
 
 var v = require('./service-helpers/validator');
 var createServiceFactory = require('./service-helpers/create-service-factory');
-var objectMap = require('./service-helpers/object-map');
 var objectClean = require('./service-helpers/object-clean');
 var urlUtils = require('../lib/helpers/url-utils');
+var stringifyBooleans = require('./service-helpers/stringify-booleans');
 
 /**
  * Map Matching API service.
@@ -136,25 +136,22 @@ MapMatching.getMatching = function(config) {
       .join(';');
   }
 
-  var body = objectClean({
-    annotations: config.annotations,
-    geometries: config.geometries,
-    language: config.language,
-    overview: config.overview,
-    steps: config.steps,
-    tidy: config.tidy,
-    approaches: path.approach,
-    radiuses: path.radius,
-    waypoints: path.isWaypoint,
-    timestamps: path.timestamp,
-    waypoint_names: path.waypointName,
-    coordinates: path.coordinates
-  });
-
-  body = objectMap(body, function(_, value) {
-    // appendQueryObject doesn't stringify booleans
-    return typeof value === 'boolean' ? JSON.stringify(value) : value;
-  });
+  var body = stringifyBooleans(
+    objectClean({
+      annotations: config.annotations,
+      geometries: config.geometries,
+      language: config.language,
+      overview: config.overview,
+      steps: config.steps,
+      tidy: config.tidy,
+      approaches: path.approach,
+      radiuses: path.radius,
+      waypoints: path.isWaypoint,
+      timestamps: path.timestamp,
+      waypoint_names: path.waypointName,
+      coordinates: path.coordinates
+    })
+  );
 
   // the matching api expects a form-urlencoded
   // post request.

--- a/services/service-helpers/stringify-booleans.js
+++ b/services/service-helpers/stringify-booleans.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var objectMap = require('./object-map');
+
+/**
+ * Stringify all the boolean values in an object, so true becomes "true".
+ *
+ * @param {Object} obj
+ * @returns {Object}
+ */
+function stringifyBoolean(obj) {
+  return objectMap(obj, function(_, value) {
+    return typeof value === 'boolean' ? JSON.stringify(value) : value;
+  });
+}
+
+module.exports = stringifyBoolean;

--- a/test/try-browser/try-browser.js
+++ b/test/try-browser/try-browser.js
@@ -11,6 +11,8 @@ var mbxDirections = require('../../services/directions');
 var mbxMapMatching = require('../../services/map-matching');
 var mbxMatrix = require('../../services/matrix');
 var mbxUploads = require('../../services/uploads');
+var mbxGeocoding = require('../../services/geocoding');
+var mbxStatic = require('../../services/static');
 
 window.tryServiceMethod = function(
   serviceName,
@@ -40,7 +42,9 @@ window.tryServiceMethod = function(
     directions: mbxDirections(baseClient),
     mapMatching: mbxMapMatching(baseClient),
     matrix: mbxMatrix(baseClient),
-    uploads: mbxUploads(baseClient)
+    uploads: mbxUploads(baseClient),
+    geocoding: mbxGeocoding(baseClient),
+    static: mbxStatic(baseClient)
   };
 
   var service = services[serviceName];


### PR DESCRIPTION
Closes #246.

I search https://www.mapbox.com/api-documentation for other possible culprits — query parameters that accept the strings `true` and `false` — and found another in the Geocoding API.

I confirmed with `npm run try-browser` that these options now seem to be behaving properly.

@kepta for review.