### PR TITLE
Reject invalid request config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## HEAD
+
+- **Change:** Throw validation error if request configuration object includes invalid properties. This is a breaking change because it could cause your code to throw a new validation error informing you of a mistake in your code. But there is no change to the library's functionality: you'll just need to clean up invalid properties.
+
 ## 0.2.0
 
-- **Add:** Add Optimization API service. 
+- **Add:** Add Optimization API service.
 
 ## 0.1.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@mapbox/fusspot": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.1.0.tgz",
-      "integrity": "sha512-mofa001UbipSNxpH7F7kz6MjPCZCFkPT145g+GHQMWFX1Fk9ahrAsgpJEoalxF3zwd0f761h7Aq8loEfqm5T3g==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.2.1.tgz",
+      "integrity": "sha512-zhyTs/Di7z5sBUwYjHRNghGsrTzB+n4UUiG8RH2IEgXEa5OHAWSdqBayTmtVUF9U7YnFce0bwN3wHIZRa8vyEQ==",
       "requires": {
         "is-plain-obj": "^1.1.0",
         "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@mapbox/fusspot": "^0.1.0",
+    "@mapbox/fusspot": "^0.2.1",
     "@mapbox/parse-mapbox-token": "^0.2.0",
     "@mapbox/polyline": "^1.0.0",
     "eventemitter3": "^3.1.0",

--- a/services/__tests__/tokens.test.js
+++ b/services/__tests__/tokens.test.js
@@ -122,13 +122,12 @@ describe('updateToken', () => {
     tokens.updateToken({
       tokenId: 'foo',
       scopes: ['styles:list'],
-      ownerId: 'chickentooth',
       note: 'horseleg',
       resources: ['one', 'two']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId/:tokenId',
-      params: { tokenId: 'foo', ownerId: 'chickentooth' },
+      params: { tokenId: 'foo' },
       method: 'PATCH',
       body: {
         scopes: ['styles:list'],

--- a/services/service-helpers/validator.js
+++ b/services/service-helpers/validator.js
@@ -19,7 +19,7 @@ function file(value) {
 }
 
 function assertShape(validatorObj, apiName) {
-  return v.assert(v.shape(validatorObj), apiName);
+  return v.assert(v.strictShape(validatorObj), apiName);
 }
 
 module.exports = xtend(v, {


### PR DESCRIPTION
Uses updated Fusspot's `strictShape` assertion.

Closes #239.

This helped me catch an outdated test in `tokens.test.js`! Besides that unintentional verification, I intentionally verified by confirming that if I change a test to add invalid properties to a request config, I get the expected error.

@danswick for review.