### PR TITLE
Reverse coordinates before sending them to polyline.encode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- **Fix:** Fix bug in `Static#getStaticImage` that resulted in reversed coordinates when creating a polyline overlay.
+
 ## 0.3.0
 
 - **Change:** Rename `MapMatching#getMatching` to `MapMatching#getMatch`.

--- a/docs/services.md
+++ b/docs/services.md
@@ -861,7 +861,7 @@ Type: [Object][110]
 #### Properties
 
 - `path` **[Object][110]** 
-  - `path.coordinates` **[Array][120]&lt;\[[number][114], [number][114]]>** An array of coordinates
+  - `path.coordinates` **[Array][120]&lt;[Coordinates][123]>** An array of coordinates
       describing the path.
   - `path.strokeWidth` **[number][114]?** 
   - `path.strokeColor` **[string][111]?** 

--- a/services/__tests__/static.test.js
+++ b/services/__tests__/static.test.js
@@ -1,5 +1,12 @@
 'use strict';
 
+jest.mock('@mapbox/polyline', () => {
+  return {
+    encode: jest.fn(() => 'mock polyline')
+  };
+});
+
+const polyline = require('@mapbox/polyline');
 const staticService = require('../static');
 const tu = require('../../test/test-utils');
 
@@ -258,10 +265,14 @@ describe('getStaticImage', () => {
     expect(tu.requestConfig(service)).toEqual({
       method: 'GET',
       path:
-        '/styles/v1/:ownerId/:styleId/static/path(wzrp%40uks%7C%40maiG%7B_wa%40)/12,13,3/200x300',
+        '/styles/v1/:ownerId/:styleId/static/path(mock%20polyline)/12,13,3/200x300',
       query: {},
       params: { ownerId: 'mapbox', styleId: 'streets-v10' }
     });
+    expect(polyline.encode).toHaveBeenCalledWith([
+      [10.098670120603392, 8.1298828125],
+      [15.792253570362446, 9.4921875]
+    ]);
   });
 
   test('with fancy polyline overlay', () => {
@@ -293,9 +304,15 @@ describe('getStaticImage', () => {
     expect(tu.requestConfig(service)).toEqual({
       method: 'GET',
       path:
-        '/styles/v1/:ownerId/:styleId/static/path-10+ff0000-0.4+000-0.75(wzrp%40uks%7C%40maiG%7B_wa%40ei%7DLr%60zH%7Cnr%40lplN)/12,13,3/200x300',
+        '/styles/v1/:ownerId/:styleId/static/path-10+ff0000-0.4+000-0.75(mock%20polyline)/12,13,3/200x300',
       query: {},
       params: { ownerId: 'mapbox', styleId: 'streets-v10' }
     });
+    expect(polyline.encode).toHaveBeenCalledWith([
+      [10.098670120603392, 8.1298828125],
+      [15.792253570362446, 9.4921875],
+      [14.179186142354181, 11.77734375],
+      [11.6522364041154, 11.513671874999998]
+    ]);
   });
 });

--- a/services/static.js
+++ b/services/static.js
@@ -221,7 +221,11 @@ function encodePathOverlay(o) {
   if (o.fillOpacity) {
     result += '-' + o.fillOpacity;
   }
-  var encodedPolyline = polyline.encode(o.coordinates);
+  // polyline expects each coordinate to be in reversed order: [lat, lng]
+  var reversedCoordinates = o.coordinates.map(function(c) {
+    return c.reverse();
+  });
+  var encodedPolyline = polyline.encode(reversedCoordinates);
   result += '(' + encodeURIComponent(encodedPolyline) + ')';
   return result;
 }

--- a/services/static.js
+++ b/services/static.js
@@ -176,7 +176,7 @@ function encodeCustomMarkerOverlay(o) {
  * A stylable line.
  * @typedef {Object} PathOverlay
  * @property {Object} path
- * @property {Array<[number, number]>} path.coordinates - An array of coordinates
+ * @property {Array<Coordinates>} path.coordinates - An array of coordinates
  *   describing the path.
  * @property {number} [path.strokeWidth]
  * @property {string} [path.strokeColor]


### PR DESCRIPTION
Closes #266.

@danswick for review, please. The details in #266 are helpful for manually reproducing the original bug and verifying the fix.