### PR TITLE
Fix CORS bug when combining Firefox and the Tilequery API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- **Fix:** Fix a CORS-related bug that caused Firefox to send preflight `OPTIONS` requests that were rejected by the server. This bug surfaced in Firefox with the Tilequery API, but may possibly have affected some other endpoints and some other browsers.
+
 ## 0.4.0
 
 - **Breaking change & fix:** Config for `Static#getStaticImage` now includes a `position` property that can be either `"auto"` or an object with `coordinates`, `zoom`, etc., properties. This fixes buggy behavior with the `"auto"` keyboard by forcing it to be mutually exclusive with all other positioning options.

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -31,6 +31,7 @@ The `emitter` property is an `EventEmitter` that emits the following events:
 - `'error'` - Listeners will be called with a `MapiError`.
 - `'downloadProgress'` - Listeners will be called with `ProgressEvents`.
 - `'uploadProgress'` - Listeners will be called with `ProgressEvents`.
+  Upload events are only available when the request includes a file.
 
 ### Properties
 

--- a/lib/browser/__tests__/browser-layer.test.js
+++ b/lib/browser/__tests__/browser-layer.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const browserLayer = require('../browser-layer');
+
+describe('sendRequestXhr', () => {
+  test('upload progress event is not assigned if the request does not include a body or file', () => {
+    const request = { id: 'fake' };
+    const xhr = {
+      send: jest.fn(),
+      upload: {},
+      getAllResponseHeaders: jest.fn()
+    };
+
+    const send = browserLayer.sendRequestXhr(request, xhr);
+    xhr.status = 200;
+    xhr.response = 'fake response';
+    xhr.onload();
+    return send.then(() => {
+      expect(xhr.upload).not.toHaveProperty('onprogress');
+    });
+  });
+
+  test('upload progress event is not assigned if the request includes a body', () => {
+    const request = { id: 'fake', body: 'really fake' };
+    const xhr = {
+      send: jest.fn(),
+      upload: {},
+      getAllResponseHeaders: jest.fn()
+    };
+
+    const send = browserLayer.sendRequestXhr(request, xhr);
+    xhr.status = 200;
+    xhr.response = 'fake response';
+    xhr.onload();
+    return send.then(() => {
+      expect(xhr.upload).not.toHaveProperty('onprogress');
+    });
+  });
+
+  test('upload progress event is assigned if the request includes a file', () => {
+    const request = { id: 'fake', file: {} };
+    const xhr = {
+      send: jest.fn(),
+      upload: {},
+      getAllResponseHeaders: jest.fn()
+    };
+
+    const send = browserLayer.sendRequestXhr(request, xhr);
+    xhr.status = 200;
+    xhr.response = 'fake response';
+    xhr.onload();
+    return send.then(() => {
+      expect(xhr.upload).toHaveProperty('onprogress');
+    });
+  });
+});

--- a/lib/browser/browser-layer.js
+++ b/lib/browser/browser-layer.js
@@ -43,12 +43,15 @@ function sendRequestXhr(request, xhr) {
       );
     };
 
-    xhr.upload.onprogress = function(event) {
-      request.emitter.emit(
-        constants.EVENT_PROGRESS_UPLOAD,
-        normalizeBrowserProgressEvent(event)
-      );
-    };
+    var file = request.file;
+    if (file) {
+      xhr.upload.onprogress = function(event) {
+        request.emitter.emit(
+          constants.EVENT_PROGRESS_UPLOAD,
+          normalizeBrowserProgressEvent(event)
+        );
+      };
+    }
 
     xhr.onerror = function(error) {
       reject(error);
@@ -77,7 +80,6 @@ function sendRequestXhr(request, xhr) {
     };
 
     var body = request.body;
-    var file = request.file;
 
     // matching service needs to send a www-form-urlencoded request
     if (typeof body === 'string') {

--- a/lib/classes/mapi-request.js
+++ b/lib/classes/mapi-request.js
@@ -20,6 +20,7 @@ var requestId = 1;
  * - `'error'` - Listeners will be called with a `MapiError`.
  * - `'downloadProgress'` - Listeners will be called with `ProgressEvents`.
  * - `'uploadProgress'` - Listeners will be called with `ProgressEvents`.
+ *   Upload events are only available when the request includes a file.
  *
  * @class MapiRequest
  * @property {EventEmitter} emitter - An event emitter. See above.


### PR DESCRIPTION
We noticed a bug where Firefox was sending preflight `OPTIONS` requests to the Tilequery API that the server was rejecting. 

The Tilequery backend is not currently configured to handle CORS because it doesn't really *need* to: its work can be done via ["simple requests"](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests). We thought the SDK was sending "simple requests" when possible, so avoiding unnecessary preflight requests — in Chrome and some other browsers it *was*. But at the bottom of the list of things that make requests non-simple there's this trick:

> one or more event listeners are registered on an XMLHttpRequestUpload object used in the request.

Most browsers were ignoring this detail in the spec, whereas Firefox was not. And most of our APIs were avoiding the Firefox bug because they handled CORS preflight requests, whereas Tilequery was not. Put those together and you get an error.

This PR remedies the situation by only attaching upload event listeners if the request includes a file — in which case it's not going to be "simple" anyway.

The current bad behavior can be reproduced by using `npm run try-browser`, opening the page in Firefox, and (setting a public access token) running this:

```
tryServiceMethod('tilequery', 'listFeatures', {
  "mapIds": ["mapbox.mapbox-streets-v7"],
  "coordinates": [-122.42901,37.80633]
}).send()
```

The same request will work in Firefox now.

@kepta for review, please.

cc @mapsam