### PR TITLE
New tests and small tweaks to improve test coverage

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -55,7 +55,7 @@ The `emitter` property is an `EventEmitter` that emits the following events:
     a URL query string.
 - `params` **[Object][24]** A route parameters object, whose values will
     be interpolated the path.
-- `headers` **[Object][24]** The request's headers,
+- `headers` **[Object][24]** The request's headers.
 - `body` **([Object][24] \| [string][23] | null)** Data to send with the request.
     If the request has a body, it will also be sent with the header
     `'Content-Type: application/json'`.

--- a/docs/services.md
+++ b/docs/services.md
@@ -721,9 +721,9 @@ See the [corresponding HTTP service documentation][161].
 
 #### Parameters
 
-- `config` **[Object][110]?** 
-  - `config.expires` **[string][111]?** 
-  - `config.scopes` **[Array][120]&lt;[string][111]>?** 
+- `config` **[Object][110]** 
+  - `config.expires` **[string][111]** 
+  - `config.scopes` **[Array][120]&lt;[string][111]>** 
 
 Returns **MapiRequest** 
 

--- a/lib/browser/__tests__/browser-layer.test.js
+++ b/lib/browser/__tests__/browser-layer.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const browserLayer = require('../browser-layer');
+const constants = require('../../constants');
 
 describe('sendRequestXhr', () => {
   test('upload progress event is not assigned if the request does not include a body or file', () => {
@@ -52,5 +53,56 @@ describe('sendRequestXhr', () => {
     return send.then(() => {
       expect(xhr.upload).toHaveProperty('onprogress');
     });
+  });
+
+  test('upload progress event is normalized and emitted', () => {
+    const request = {
+      id: 'fake',
+      file: {},
+      emitter: {
+        emit: jest.fn()
+      }
+    };
+    const xhr = {
+      send: jest.fn(),
+      upload: {},
+      getAllResponseHeaders: jest.fn()
+    };
+    const mockEvent = {
+      total: 26,
+      loaded: 13
+    };
+
+    const send = browserLayer.sendRequestXhr(request, xhr);
+    xhr.status = 200;
+    xhr.response = 'fake response';
+    xhr.onload();
+    return send.then(() => {
+      xhr.upload.onprogress(mockEvent);
+      expect(request.emitter.emit).toHaveBeenCalledWith(
+        constants.EVENT_PROGRESS_UPLOAD,
+        {
+          total: 26,
+          transferred: 13,
+          percent: 50
+        }
+      );
+    });
+  });
+
+  test('XHR-initialization error causes Promise to reject', () => {
+    const request = { id: 'fake', body: 'really fake' };
+    const xhr = {
+      send: jest.fn(),
+      upload: {},
+      getAllResponseHeaders: jest.fn()
+    };
+    const mockError = new Error();
+
+    const send = browserLayer.sendRequestXhr(request, xhr);
+    xhr.status = 200;
+    xhr.response = 'fake response';
+    xhr.onerror(mockError);
+    expect(send).rejects.toThrow(mockError);
   });
 });

--- a/lib/browser/browser-layer.js
+++ b/lib/browser/browser-layer.js
@@ -104,11 +104,9 @@ function createRequestXhr(request, accessToken) {
   var url = request.url(accessToken);
   var xhr = new window.XMLHttpRequest();
   xhr.open(request.method, url);
-  if (request.headers) {
-    Object.keys(request.headers).forEach(function(key) {
-      xhr.setRequestHeader(key, request.headers[key]);
-    });
-  }
+  Object.keys(request.headers).forEach(function(key) {
+    xhr.setRequestHeader(key, request.headers[key]);
+  });
   return xhr;
 }
 

--- a/lib/classes/__tests__/mapi-request.test.js
+++ b/lib/classes/__tests__/mapi-request.test.js
@@ -280,7 +280,7 @@ describe('MapiRequest#abort', () => {
 });
 
 describe('MapiRequest#url', () => {
-  test('works without an access token, appending query, inteprolating route params, prepending origin', () => {
+  test('works without an access token, appending query, interpolating route params, prepending origin', () => {
     const client = createMockClient();
     const request = new MapiRequest(client, {
       path: '/foo/:a/:b/bar',
@@ -296,7 +296,7 @@ describe('MapiRequest#url', () => {
     expect(request.url()).toBe('mockClientOrigin/foo/yep/nope/bar?fish=tuna');
   });
 
-  test('works with an access token, appending query, inteprolating route params, prepending origin', () => {
+  test('works with an access token, appending query, interpolating route params, prepending origin', () => {
     const client = createMockClient();
     const request = new MapiRequest(client, {
       path: '/foo/:a/:b/bar',

--- a/lib/classes/__tests__/mapi-request.test.js
+++ b/lib/classes/__tests__/mapi-request.test.js
@@ -7,7 +7,7 @@ function createMockClient() {
   return {
     sendRequest: jest.fn(() => Promise.resolve({ body: 'mock' })),
     abortRequest: jest.fn(),
-    _origin: 'mockClientOrigin'
+    origin: 'mockClientOrigin'
   };
 }
 
@@ -276,5 +276,42 @@ describe('MapiRequest#abort', () => {
     request.abort();
     expect(nextPageRequestAbort).toHaveBeenCalled();
     expect(request).not.toHaveProperty('nextPageRequest');
+  });
+});
+
+describe('MapiRequest#url', () => {
+  test('works without an access token, appending query, inteprolating route params, prepending origin', () => {
+    const client = createMockClient();
+    const request = new MapiRequest(client, {
+      path: '/foo/:a/:b/bar',
+      method: 'MOCK_METHOD',
+      params: {
+        a: 'yep',
+        b: 'nope'
+      },
+      query: {
+        fish: 'tuna'
+      }
+    });
+    expect(request.url()).toBe('mockClientOrigin/foo/yep/nope/bar?fish=tuna');
+  });
+
+  test('works with an access token, appending query, inteprolating route params, prepending origin', () => {
+    const client = createMockClient();
+    const request = new MapiRequest(client, {
+      path: '/foo/:a/:b/bar',
+      method: 'MOCK_METHOD',
+      params: {
+        a: 'yep',
+        b: 'nope'
+      },
+      query: {
+        fish: 'tuna'
+      }
+    });
+    const token = tu.mockToken();
+    expect(request.url(token)).toBe(
+      `mockClientOrigin/foo/yep/nope/bar?fish=tuna&access_token=${token}`
+    );
   });
 });

--- a/lib/classes/mapi-request.js
+++ b/lib/classes/mapi-request.js
@@ -43,7 +43,7 @@ var requestId = 1;
  *   a URL query string.
  * @property {Object} params - A route parameters object, whose values will
  *   be interpolated the path.
- * @property {Object} headers - The request's headers,
+ * @property {Object} headers - The request's headers.
  * @property {Object|string|null} body - Data to send with the request.
  *   If the request has a body, it will also be sent with the header
  *   `'Content-Type: application/json'`.

--- a/services/__tests__/directions.test.js
+++ b/services/__tests__/directions.test.js
@@ -193,4 +193,32 @@ describe('getDirections', () => {
       }
     });
   });
+
+  test('errors if there are too few waypoints', () => {
+    expect(() => {
+      directions.getDirections({
+        waypoints: [
+          {
+            coordinates: [2.2, 1.1],
+            radius: 2000
+          }
+        ]
+      });
+    }).toThrowError(/between 2 and 25/);
+  });
+
+  test('errors if there are too many waypoints', () => {
+    expect(() => {
+      const waypoints = [];
+      for (let i = 0; i < 26; i++) {
+        waypoints.push({
+          coordinates: [2.2, 1.1],
+          radius: 2000
+        });
+      }
+      directions.getDirections({
+        waypoints
+      });
+    }).toThrowError(/between 2 and 25/);
+  });
 });

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -11,8 +11,7 @@ beforeEach(() => {
 describe('forwardGeocode', () => {
   test('with minimal config', () => {
     geocoding.forwardGeocode({
-      query: 'Tucson',
-      mode: 'mapbox.places'
+      query: 'Tucson'
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',
@@ -60,8 +59,7 @@ describe('forwardGeocode', () => {
 describe('reverseGeocode', () => {
   test('with minimal config', () => {
     geocoding.reverseGeocode({
-      query: [15, 14],
-      mode: 'mapbox.places'
+      query: [15, 14]
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',

--- a/services/__tests__/map-matching.test.js
+++ b/services/__tests__/map-matching.test.js
@@ -186,4 +186,24 @@ describe('getMatch', () => {
       ])
     });
   });
+
+  test('errors if there are too few points', () => {
+    expect(() => {
+      mapMatching.getMatch({
+        points: [{ coordinates: [2.2, 1.1] }]
+      });
+    }).toThrowError(/between 2 and 100/);
+  });
+
+  test('errors if there are too many points', () => {
+    expect(() => {
+      const points = [];
+      for (let i = 0; i < 101; i++) {
+        points.push({ coordinates: [2.2, 1.1] });
+      }
+      mapMatching.getMatch({
+        points
+      });
+    }).toThrowError(/between 2 and 100/);
+  });
 });

--- a/services/__tests__/matrix.test.js
+++ b/services/__tests__/matrix.test.js
@@ -162,4 +162,24 @@ describe('getMatrix', () => {
       }
     });
   });
+
+  test('errors if there are too few points', () => {
+    expect(() => {
+      matrix.getMatrix({
+        points: [{ coordinates: [2.2, 1.1] }]
+      });
+    }).toThrowError(/between 2 and 100/);
+  });
+
+  test('errors if there are too many points', () => {
+    expect(() => {
+      const points = [];
+      for (let i = 0; i < 101; i++) {
+        points.push({ coordinates: [2.2, 1.1] });
+      }
+      matrix.getMatrix({
+        points
+      });
+    }).toThrowError(/between 2 and 100/);
+  });
 });

--- a/services/__tests__/static.test.js
+++ b/services/__tests__/static.test.js
@@ -351,4 +351,69 @@ describe('getStaticImage', () => {
       [11.6522364041154, 11.513671874999998]
     ]);
   });
+
+  test('catches bad polylines', () => {
+    expect(() => {
+      service.getStaticImage({
+        ownerId: 'mapbox',
+        styleId: 'streets-v10',
+        width: 200,
+        height: 300,
+        position: 'auto',
+        overlays: [
+          {
+            path: {
+              coordinates: [
+                [8.1298828125, 10.098670120603392],
+                [9.4921875, 15.792253570362446]
+              ],
+              strokeOpacity: 0.4
+            }
+          }
+        ]
+      });
+    }).toThrow(/strokeOpacity requires strokeColor/);
+
+    expect(() => {
+      service.getStaticImage({
+        ownerId: 'mapbox',
+        styleId: 'streets-v10',
+        width: 200,
+        height: 300,
+        position: 'auto',
+        overlays: [
+          {
+            path: {
+              coordinates: [
+                [8.1298828125, 10.098670120603392],
+                [9.4921875, 15.792253570362446]
+              ],
+              fillColor: '000'
+            }
+          }
+        ]
+      });
+    }).toThrow(/fillColor requires strokeColor/);
+    expect(() => {
+      service.getStaticImage({
+        ownerId: 'mapbox',
+        styleId: 'streets-v10',
+        width: 200,
+        height: 300,
+        position: 'auto',
+        overlays: [
+          {
+            path: {
+              coordinates: [
+                [8.1298828125, 10.098670120603392],
+                [9.4921875, 15.792253570362446]
+              ],
+              strokeColor: 'ff0000',
+              fillOpacity: 0.75
+            }
+          }
+        ]
+      });
+    }).toThrow(/fillOpacity requires fillColor/);
+  });
 });

--- a/services/service-helpers/__tests__/validator.test.js
+++ b/services/service-helpers/__tests__/validator.test.js
@@ -51,3 +51,26 @@ describe('v.file in Node', () => {
     ).toBeUndefined();
   });
 });
+
+describe('v.date', () => {
+  var check = t(v.date);
+
+  test('rejects values that cannot be passed to the Date constructor to create a valid date', () => {
+    expect(check(true)).toEqual(['date']);
+    expect(check('egg sandwich')).toEqual(['date']);
+    expect(check({ one: 1, two: 2 })).toEqual(['date']);
+    expect(check(() => {})).toEqual(['date']);
+    // Make the Date constructor error.
+    jest.spyOn(global, 'Date').mockImplementationOnce(() => {
+      throw new Error();
+    });
+    expect(check(1534285808537)).toEqual(['date']);
+  });
+
+  test('accepts values that can be passed to the Date constructor to create a valid date', () => {
+    expect(check(new Date())).toBeUndefined();
+    expect(check('2018-03-03')).toBeUndefined();
+    expect(check('Tue Aug 14 2018 15:29:53 GMT-0700 (MST)')).toBeUndefined();
+    expect(check(1534285808537)).toBeUndefined();
+  });
+});

--- a/services/tokens.js
+++ b/services/tokens.js
@@ -67,13 +67,12 @@ Tokens.createToken = function(config) {
  *
  * See the [corresponding HTTP service documentation](https://www.mapbox.com/api-documentation/#create-temporary-token).
  *
- * @param {Object} [config]
- * @param {string} [config.expires]
- * @param {Array<string>} [config.scopes]
+ * @param {Object} config
+ * @param {string} config.expires
+ * @param {Array<string>} config.scopes
  * @return {MapiRequest}
  */
 Tokens.createTemporaryToken = function(config) {
-  config = config || {};
   v.assertShape({
     expires: v.required(v.date),
     scopes: v.required(v.arrayOf(v.string))


### PR DESCRIPTION
This is just some work I did on the plane to increase test coverage. A few details you might have questions about:

- A `MapiRequest` always has a `headers` property that's an object, even if it's an empty one; that enabled me to delete a conditional.
- Geocoding endpoints use `'mapbox.places'` as the default mode. I tested the application of that default.

@kepta for review, please.