### PR TITLE
hasNextPage readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ req.send().then(response => {..}, error => {
 req.abort();
 
 // Paginate through a response.
-tilesetsService.listTilesets().eachPage((error, response, next) => {
+tilesetsService.listTilesets().eachPage((error, response, next) => {  
   // Do something with the page, then call next() to send the request
-  // for the next page.
+  // for the next page. If you want to check if there are any more pages to call
+  // use res.hasNextPage() first.
+  if (res.hasNextPage()) return next();
 });
 
 // Listen for uploadProgress events.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ req.send().then(response => {..}, error => {
 req.abort();
 
 // Paginate through a response.
-tilesetsService.listTilesets().eachPage((error, response, next) => {  
+tilesetsService.listTilesets().eachPage((error, response, next) => {
   // Do something with the page, then call next() to send the request
   // for the next page. If you want to check if there are any more pages to call
   // use res.hasNextPage() first.


### PR DESCRIPTION
This updates the `eachPage()` docs to include the `res.hasNextPage()` method as an example of how to check for a next page before calling `next()`, otherwise there's no current way to determine when all pages have been returned.

cc @danswick 