### PR TITLE
Add more parse-link-header tests

### DIFF
--- a/lib/helpers/__tests__/parse-link-header.test.js
+++ b/lib/helpers/__tests__/parse-link-header.test.js
@@ -146,3 +146,30 @@ test('invalid header', () => {
 test('empty header', () => {
   expect(parseLinkHeader('<>;;')).toEqual({});
 });
+
+// See https://tools.ietf.org/html/rfc5988#section-5.3
+test('if multiple rel parameters are provided, the first is used', () => {
+  const link =
+    '<https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100>; rel="next"; rel="previous"';
+
+  expect(parseLinkHeader(link)).toEqual({
+    next: {
+      url:
+        'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100',
+      params: {}
+    }
+  });
+});
+
+test('if multiple rel values are provided with a duplicate, the duplicate is ignored', () => {
+  const link =
+    '<https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100>; rel="next next"';
+
+  expect(parseLinkHeader(link)).toEqual({
+    next: {
+      url:
+        'https://api.github.com/user/9287/repos?client_id=1&client_secret=2&page=2&per_page=100',
+      params: {}
+    }
+  });
+});


### PR DESCRIPTION
A little more test coverage, towards that 100% goal (#263).

The only remaining holes are about error handling and uploads in Node.

@kepta for review, please.