### PR TITLE
include origin option in MapiClient

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -192,6 +192,8 @@ that is appropriate to the configuration and environment
 
 - `accessToken` **[string][23]** The Mapbox access token assigned
     to this client.
+- `origin` **[string][23]?** The origin
+    to use for API requests. Defaults to [https://api.mapbox.com][31].
 
 [1]: #mapirequest
 
@@ -252,3 +254,5 @@ that is appropriate to the configuration and environment
 [29]: #mapirequest
 
 [30]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[31]: https://api.mapbox.com

--- a/lib/classes/mapi-client.js
+++ b/lib/classes/mapi-client.js
@@ -16,6 +16,8 @@ var constants = require('../constants');
  * @class MapiClient
  * @property {string} accessToken - The Mapbox access token assigned
  *   to this client.
+ * @property {string} [origin] - The origin
+ *   to use for API requests. Defaults to https://api.mapbox.com.
  */
 
 function MapiClient(options) {


### PR DESCRIPTION
`MapiClient` `options.origin` is part of the public API, this PR ensures it's documented. One use case for this is changing it to `api.mapbox.cn`.