### PR TITLE
[WIP] Update map matching to filter empty waypoints

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -247,7 +247,7 @@ SDK returned.
   - `config.position` **(`"auto"` \| [Object][112])** If `"auto"`, the viewport will fit the
       bounds of the overlay(s). Otherwise, the maps' position is described by an object
       with the following properties:
-      `coordinates` (required): `[longitude, latitude]` for the center of image.
+      `coordinates` (required): [`coordinates`][106] for the center of image.
       `zoom` (required): Between 0 and 20.
       `bearing` (optional): Between 0 and 360.
       `pitch` (optional): Between 0 and 60.

--- a/docs/services.md
+++ b/docs/services.md
@@ -377,7 +377,7 @@ SDK returned.
   - `config.position` **(`"auto"` \| [Object][150])** If `"auto"`, the viewport will fit the
       bounds of the overlay(s). Otherwise, the maps' position is described by an object
       with the following properties:
-      `coordinates` (required): [`coordinates`][106] for the center of image.
+      `coordinates` (required): [`coordinates`][144] for the center of image.
       `zoom` (required): Between 0 and 20.
       `bearing` (optional): Between 0 and 360.
       `pitch` (optional): Between 0 and 60.

--- a/services/__tests__/map-matching.test.js
+++ b/services/__tests__/map-matching.test.js
@@ -62,7 +62,7 @@ describe('getMatch', () => {
       body: urlEncodeBody([
         ['geometries', 'polyline6'],
         ['tidy', 'true'],
-        ['waypoints', '0;;2;3'],
+        ['waypoints', '0;2;3'],
         ['coordinates', '2.2,1.1;2.2,1.1;3.2,1.1;4.2,1.1']
       ]),
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -133,7 +133,7 @@ describe('getMatch', () => {
       method: 'POST',
       body: urlEncodeBody([
         ['steps', 'false'],
-        ['waypoints', '0;;;3'],
+        ['waypoints', '0;3'],
         ['coordinates', '2.2,1.1;2.2,1.1;3.2,1.1;4.2,1.1']
       ]),
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -179,7 +179,7 @@ describe('getMatch', () => {
         ['steps', 'true'],
         ['approaches', ';curb;;unrestricted'],
         ['radiuses', ';;50;'],
-        ['waypoints', '0;1;;3'],
+        ['waypoints', '0;1;3'],
         ['timestamps', ';;1528157886576;1528157886888'],
         ['waypoint_names', ';;special;'],
         ['coordinates', '2.2,1.1;2.2,1.1;2.2,1.1;2.2,1.1']

--- a/services/map-matching.js
+++ b/services/map-matching.js
@@ -133,6 +133,9 @@ MapMatching.getMatch = function(config) {
       .map(function(val, i) {
         return val === true ? i : '';
       })
+      .filter(function(x) {
+        return x === 0 || Boolean(x);
+      })
       .join(';');
   }
 


### PR DESCRIPTION
Addresses part of https://github.com/mapbox/mapbox-sdk-js/issues/289. 

While verifying the map-matching service, I noticed we weren't filtering empty waypoints, which would result in a `'Waypoints must be integer indexes that reference a coordinate'` error message from the Map Matching API. This PR adds a filter to make sure we don't get any pesky stray `;` in our `waypoints` list. 

@kepta for review, please 🙏 

todo: 

- [x] Update tests