### PR TITLE
Allow referrers and resources to have  null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## HEAD
+
+- **Fix:** `Tokens#updateToken` can now set `null` value to `referrers` property to delete the property.
+- **Fix:** `Tokens#updateToken` can now set `null` value to `resources` property to delete the property.
+
 ## 0.5.0
 
 - **Add:** Config for `Tokens#createToken` and `Tokens#updateToken` can now include the `referrers` property.

--- a/services/__tests__/tokens.test.js
+++ b/services/__tests__/tokens.test.js
@@ -176,6 +176,19 @@ describe('updateToken', () => {
     });
   });
 
+  test('resources can be null', () => {
+    tokens.updateToken({
+      tokenId: 'foo',
+      resources: null
+    });
+    expect(tu.requestConfig(tokens)).toEqual({
+      path: '/tokens/v2/:ownerId/:tokenId',
+      params: { tokenId: 'foo' },
+      method: 'PATCH',
+      body: { resources: null }
+    });
+  });
+
   test('with referrers', () => {
     tokens.updateToken({
       tokenId: 'foo',
@@ -188,6 +201,20 @@ describe('updateToken', () => {
       body: { referrers: ['boba.com', 'milk-tea.ca'] }
     });
   });
+
+  test('referrers can be null', () => {
+    tokens.updateToken({
+      tokenId: 'foo',
+      referrers: null
+    });
+    expect(tu.requestConfig(tokens)).toEqual({
+      path: '/tokens/v2/:ownerId/:tokenId',
+      params: { tokenId: 'foo' },
+      method: 'PATCH',
+      body: { referrers: null }
+    });
+  });
+
 
   test('with scopes', () => {
     tokens.updateToken({

--- a/services/tokens.js
+++ b/services/tokens.js
@@ -160,10 +160,10 @@ Tokens.updateToken = function(config) {
   if (config.note !== undefined) {
     body.note = config.note;
   }
-  if (config.resources) {
+  if (config.resources || config.resources === null) {
     body.resources = config.resources;
   }
-  if (config.referrers) {
+  if (config.referrers || config.referrers === null) {
     body.referrers = config.referrers;
   }
 


### PR DESCRIPTION
This allow for passing a `null` value to `resources` or `referrers` properties in `Tokens#updateToken` to delete the respective property.

@davidtheclark or @danswick for review, please.