### PR TITLE
Swap all references to `referrers` to `allowedUrls`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **Fix:** `Tokens#updateToken` can now set `null` value to `referrers` property to delete the property.
 - **Fix:** `Tokens#updateToken` can now set `null` value to `resources` property to delete the property.
-- **Breaking change**: change all references to `referrer`[s] to `allowedUrl`[s].
+- **Breaking change**: change all references to `referrer`{s} to `allowedUrl`{s}.
 
 ## 0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **Fix:** `Tokens#updateToken` can now set `null` value to `referrers` property to delete the property.
 - **Fix:** `Tokens#updateToken` can now set `null` value to `resources` property to delete the property.
+- **Breaking change**: change all references to `referrer`[s] to `allowedUrl`[s].
 
 ## 0.5.0
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1325,7 +1325,7 @@ See the [corresponding HTTP service documentation][201].
   - `config.note` **[string][151]?** 
   - `config.scopes` **[Array][160]&lt;[string][151]>?** 
   - `config.resources` **[Array][160]&lt;[string][151]>?** 
-  - `config.referrers` **[Array][160]&lt;[string][151]>?** 
+  - `config.allowedUrls` **[Array][160]&lt;[string][151]>?** 
 
 #### Examples
 
@@ -1381,7 +1381,7 @@ See the [corresponding HTTP service documentation][203].
   - `config.note` **[string][151]?** 
   - `config.scopes` **[Array][160]&lt;[string][151]>?** 
   - `config.resources` **[Array][160]&lt;[string][151]>?** 
-  - `config.referrers` **[Array][160]&lt;[string][151]>?** 
+  - `config.allowedUrls` **[Array][160]&lt;[string][151]>?** 
 
 #### Examples
 

--- a/services/__tests__/tokens.test.js
+++ b/services/__tests__/tokens.test.js
@@ -58,16 +58,16 @@ describe('createToken', () => {
     });
   });
 
-  test('with referrers', () => {
+  test('with allowedUrls', () => {
     tokens.createToken({
-      referrers: ['boba.com', 'coffee.ca']
+      allowedUrls: ['boba.com', 'coffee.ca']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId',
       method: 'POST',
       params: {},
       body: {
-        referrers: ['boba.com', 'coffee.ca'],
+        allowedUrls: ['boba.com', 'coffee.ca'],
         scopes: []
       }
     });
@@ -88,7 +88,7 @@ describe('createToken', () => {
       scopes: ['styles:list'],
       note: 'horseleg',
       resources: ['one', 'two'],
-      referrers: ['boba.com', 'coffee.ca']
+      allowedUrls: ['boba.com', 'coffee.ca']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId',
@@ -98,7 +98,7 @@ describe('createToken', () => {
         scopes: ['styles:list'],
         note: 'horseleg',
         resources: ['one', 'two'],
-        referrers: ['boba.com', 'coffee.ca']
+        allowedUrls: ['boba.com', 'coffee.ca']
       }
     });
   });
@@ -189,29 +189,29 @@ describe('updateToken', () => {
     });
   });
 
-  test('with referrers', () => {
+  test('with allowedUrls', () => {
     tokens.updateToken({
       tokenId: 'foo',
-      referrers: ['boba.com', 'milk-tea.ca']
+      allowedUrls: ['boba.com', 'milk-tea.ca']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId/:tokenId',
       params: { tokenId: 'foo' },
       method: 'PATCH',
-      body: { referrers: ['boba.com', 'milk-tea.ca'] }
+      body: { allowedUrls: ['boba.com', 'milk-tea.ca'] }
     });
   });
 
-  test('referrers can be null', () => {
+  test('allowedUrls can be null', () => {
     tokens.updateToken({
       tokenId: 'foo',
-      referrers: null
+      allowedUrls: null
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId/:tokenId',
       params: { tokenId: 'foo' },
       method: 'PATCH',
-      body: { referrers: null }
+      body: { allowedUrls: null }
     });
   });
 
@@ -235,7 +235,7 @@ describe('updateToken', () => {
       scopes: ['styles:list'],
       note: 'horseleg',
       resources: ['one', 'two'],
-      referrers: ['boba.com', 'milk-tea.ca']
+      allowedUrls: ['boba.com', 'milk-tea.ca']
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId/:tokenId',
@@ -245,7 +245,7 @@ describe('updateToken', () => {
         scopes: ['styles:list'],
         note: 'horseleg',
         resources: ['one', 'two'],
-        referrers: ['boba.com', 'milk-tea.ca']
+        allowedUrls: ['boba.com', 'milk-tea.ca']
       }
     });
   });

--- a/services/tokens.js
+++ b/services/tokens.js
@@ -42,7 +42,7 @@ Tokens.listTokens = function() {
  * @param {string} [config.note]
  * @param {Array<string>} [config.scopes]
  * @param {Array<string>} [config.resources]
- * @param {Array<string>} [config.referrers]
+ * @param {Array<string>} [config.allowedUrls]
  * @return {MapiRequest}
  *
  * @example
@@ -61,7 +61,7 @@ Tokens.createToken = function(config) {
     note: v.string,
     scopes: v.arrayOf(v.string),
     resources: v.arrayOf(v.string),
-    referrers: v.arrayOf(v.string)
+    allowedUrls: v.arrayOf(v.string)
   })(config);
 
   var body = {};
@@ -72,8 +72,8 @@ Tokens.createToken = function(config) {
   if (config.resources) {
     body.resources = config.resources;
   }
-  if (config.referrers) {
-    body.referrers = config.referrers;
+  if (config.allowedUrls) {
+    body.allowedUrls = config.allowedUrls;
   }
 
   return this.client.createRequest({
@@ -130,7 +130,7 @@ Tokens.createTemporaryToken = function(config) {
  * @param {string} [config.note]
  * @param {Array<string>} [config.scopes]
  * @param {Array<string>} [config.resources]
- * @param {Array<string>} [config.referrers]
+ * @param {Array<string>} [config.allowedUrls]
  * @return {MapiRequest}
  *
  * @example
@@ -150,7 +150,7 @@ Tokens.updateToken = function(config) {
     note: v.string,
     scopes: v.arrayOf(v.string),
     resources: v.arrayOf(v.string),
-    referrers: v.arrayOf(v.string)
+    allowedUrls: v.arrayOf(v.string)
   })(config);
 
   var body = {};
@@ -163,8 +163,8 @@ Tokens.updateToken = function(config) {
   if (config.resources || config.resources === null) {
     body.resources = config.resources;
   }
-  if (config.referrers || config.referrers === null) {
-    body.referrers = config.referrers;
+  if (config.allowedUrls || config.allowedUrls === null) {
+    body.allowedUrls = config.allowedUrls;
   }
 
   return this.client.createRequest({


### PR DESCRIPTION
As part of our impending token restrictions launch, we're transitioning our terminology from "referrers" to "allowedUrls". This PR swaps all references to `referrer` or `referrers` to `allowedUrl` or `allowedUrls`. 

@kepta for review, please 🙏 

cc @lshig 