### PR TITLE
fix url() token placement for service with clients

### DIFF
--- a/lib/classes/__tests__/mapi-client.test.js
+++ b/lib/classes/__tests__/mapi-client.test.js
@@ -3,6 +3,7 @@
 const MapiClient = require('../mapi-client');
 const tu = require('../../../test/test-utils');
 const constants = require('../../constants');
+const mbxStatic = require('../../../services/static');
 
 test('errors without options', () => {
   tu.expectError(
@@ -40,4 +41,48 @@ test('errors with an invalid accessToken', () => {
 test('origin defaults to the standard public origin', () => {
   const client = new MapiClient({ accessToken: tu.mockToken() });
   expect(client.origin).toBe(constants.API_ORIGIN);
+});
+
+test('properly adds access token to url() when a service client has token', () => {
+  const client = new MapiClient({
+    accessToken: tu.mockToken()
+  });
+  const staticServ = mbxStatic(client);
+  expect(staticServ.client.accessToken).toBe(client.accessToken);
+
+  expect(
+    staticServ
+      .getStaticImage({
+        ownerId: 'mapbox',
+        styleId: 'streets-v11',
+        width: 200,
+        height: 300,
+        position: {
+          coordinates: [12, 13],
+          zoom: 4
+        }
+      })
+      .url()
+  ).toMatch(client.accessToken);
+});
+
+test('properly adds access token to url() when service token is passed in', () => {
+  const staticServ = mbxStatic({
+    accessToken: tu.mockToken()
+  });
+
+  expect(
+    staticServ
+      .getStaticImage({
+        ownerId: 'mapbox',
+        styleId: 'streets-v11',
+        width: 200,
+        height: 300,
+        position: {
+          coordinates: [12, 13],
+          zoom: 4
+        }
+      })
+      .url()
+  ).toMatch(staticServ.client.accessToken);
 });

--- a/lib/classes/mapi-request.js
+++ b/lib/classes/mapi-request.js
@@ -119,9 +119,11 @@ MapiRequest.prototype.url = function url(accessToken) {
   var url = urlUtils.prependOrigin(this.path, this.origin);
   url = urlUtils.appendQueryObject(url, this.query);
   var routeParams = this.params;
-  if (accessToken) {
-    url = urlUtils.appendQueryParam(url, 'access_token', accessToken);
-    var accessTokenOwnerId = parseToken(accessToken).user;
+  var actualAccessToken =
+    accessToken == null ? this.client.accessToken : accessToken;
+  if (actualAccessToken) {
+    url = urlUtils.appendQueryParam(url, 'access_token', actualAccessToken);
+    var accessTokenOwnerId = parseToken(actualAccessToken).user;
     routeParams = xtend({ ownerId: accessTokenOwnerId }, routeParams);
   }
   url = urlUtils.interpolateRouteParams(url, routeParams);


### PR DESCRIPTION
When I was creating a service to generate Static urls, I noticed the access token I specified during service creation wasn't being appended. I believe this covers that.