### PR TITLE
Add routing as an option on geocoding

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1516,6 +1516,7 @@ See the [public documentation][235].
      Options are [IETF language tags][233] comprised of a mandatory
      [ISO 639-1 language code][234] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
+  - `config.routing` **[boolean][158]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
 
 #### Examples
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1448,6 +1448,7 @@ See the [public documentation][230].
   - `config.language` **[Array][206]&lt;[string][197]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
      Options are [IETF language tags][233] comprised of a mandatory
      [ISO 639-1 language code][234] and optionally one or more IETF subtags for country or script.
+  - `config.routing` **[boolean][198]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
 
 #### Examples
 
@@ -1516,7 +1517,7 @@ See the [public documentation][235].
      Options are [IETF language tags][233] comprised of a mandatory
      [ISO 639-1 language code][234] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-  - `config.routing` **[boolean][158]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+  - `config.routing` **[boolean][198]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
 
 #### Examples
 

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -34,7 +34,8 @@ describe('forwardGeocode', () => {
       autocomplete: true,
       bbox: [1, 2, 3, 4],
       limit: 3,
-      language: ['de', 'bs']
+      language: ['de', 'bs'],
+      routing: true
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',
@@ -50,7 +51,8 @@ describe('forwardGeocode', () => {
         autocomplete: 'true',
         bbox: [1, 2, 3, 4],
         limit: 3,
-        language: ['de', 'bs']
+        language: ['de', 'bs'],
+        routing: 'true'
       }
     });
   });

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -81,7 +81,8 @@ describe('reverseGeocode', () => {
       bbox: [1, 2, 3, 4],
       limit: 3,
       language: ['de', 'bs'],
-      reverseMode: 'distance'
+      reverseMode: 'distance',
+      routing: true
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',
@@ -96,7 +97,8 @@ describe('reverseGeocode', () => {
         bbox: [1, 2, 3, 4],
         limit: 3,
         language: ['de', 'bs'],
-        reverseMode: 'distance'
+        reverseMode: 'distance',
+        routing: 'true'
       }
     });
   });

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -45,6 +45,7 @@ var featureTypes = [
  * @param {Array<string>} [config.language] - Specify the language to use for response text and, for forward geocoding, query result weighting.
  *  Options are [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) comprised of a mandatory
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
+ * @param {boolean} [config.routing] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
  * @return {MapiRequest}
  *
  * @example
@@ -98,7 +99,8 @@ Geocoding.forwardGeocode = function(config) {
     autocomplete: v.boolean,
     bbox: v.arrayOf(v.number),
     limit: v.number,
-    language: v.arrayOf(v.string)
+    language: v.arrayOf(v.string),
+    routing: v.boolean
   })(config);
 
   config.mode = config.mode || 'mapbox.places';
@@ -112,7 +114,8 @@ Geocoding.forwardGeocode = function(config) {
         'autocomplete',
         'bbox',
         'limit',
-        'language'
+        'language',
+        'routing'
       ])
     )
   );

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -45,7 +45,7 @@ var featureTypes = [
  * @param {Array<string>} [config.language] - Specify the language to use for response text and, for forward geocoding, query result weighting.
  *  Options are [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) comprised of a mandatory
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
- * @param {boolean} [config.routing] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+ * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
  * @return {MapiRequest}
  *
  * @example

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -145,7 +145,7 @@ Geocoding.forwardGeocode = function(config) {
  *  Options are [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) comprised of a mandatory
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {'distance'|'score'} [config.reverseMode='distance'] - Set the factors that are used to sort nearby results.
- * @param {boolean} [config.routing] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+ * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
  * @return {MapiRequest}
  *
  * @example

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -142,6 +142,7 @@ Geocoding.forwardGeocode = function(config) {
  *  Options are [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) comprised of a mandatory
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {'distance'|'score'} [config.reverseMode='distance'] - Set the factors that are used to sort nearby results.
+ * @param {boolean} [config.routing] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
  * @return {MapiRequest}
  *
  * @example
@@ -163,7 +164,8 @@ Geocoding.reverseGeocode = function(config) {
     bbox: v.arrayOf(v.number),
     limit: v.number,
     language: v.arrayOf(v.string),
-    reverseMode: v.oneOf('distance', 'score')
+    reverseMode: v.oneOf('distance', 'score'),
+    routing: v.boolean
   })(config);
 
   config.mode = config.mode || 'mapbox.places';
@@ -177,7 +179,8 @@ Geocoding.reverseGeocode = function(config) {
         'bbox',
         'limit',
         'language',
-        'reverseMode'
+        'reverseMode',
+        'routing'
       ])
     )
   );


### PR DESCRIPTION
noticed the API has a routing option on geocoding that was not in the SDK, preventing responses that contain the routable_points