### PR TITLE
add missing `geometry` key to config and query in Tilequery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## Master
+
+- **Fix:** add missing `geometry` key to Tilequery service. 
+
 ## 0.7.0
 
-- **Fix:** filter empty waypoints from map matching requests. 
-- **Fix:** fix url token placement for service with clients. 
+- **Fix:** filter empty waypoints from map matching requests.
+- **Fix:** fix url token placement for service with clients.
 
 ## 0.6.0
 

--- a/services/__tests__/tilequery.test.js
+++ b/services/__tests__/tilequery.test.js
@@ -48,7 +48,8 @@ describe('listFeatures', () => {
       radius: 39,
       limit: 3,
       dedupe: false,
-      layers: ['egg', 'sandwich']
+      layers: ['egg', 'sandwich'],
+      geometry: 'point'
     });
     expect(tu.requestConfig(tilequery)).toEqual({
       path: '/v4/:mapIds/tilequery/:coordinates.json',
@@ -61,7 +62,8 @@ describe('listFeatures', () => {
         radius: 39,
         limit: 3,
         dedupe: false,
-        layers: ['egg', 'sandwich']
+        layers: ['egg', 'sandwich'],
+        geometry: 'point'
       }
     });
   });

--- a/services/tilequery.js
+++ b/services/tilequery.js
@@ -44,6 +44,7 @@ Tilequery.listFeatures = function(config) {
     radius: v.number,
     limit: v.range([1, 50]),
     dedupe: v.boolean,
+    geometry: v.oneOf('polygon', 'linestring', 'point'),
     layers: v.arrayOf(v.string)
   })(config);
 
@@ -54,7 +55,7 @@ Tilequery.listFeatures = function(config) {
       mapIds: config.mapIds,
       coordinates: config.coordinates
     },
-    query: pick(config, ['radius', 'limit', 'dedupe', 'layers'])
+    query: pick(config, ['radius', 'limit', 'dedupe', 'layers', 'geometry'])
   });
 };
 


### PR DESCRIPTION
When testing the Tilequery API, I received the following error when passing `geometry` to the config:

> Uncaught Error: The following keys are invalid: geometry

I believe this error is due to `geometry` missing from the `config` and `query` - this PR fixes that.

