### PR TITLE
fix example for reverse geocoding to use limit: 1

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1114,7 +1114,7 @@ See the [public documentation][191].
 ```javascript
 geocodingClient.reverseGeocode({
   query: [-95.4431142, 33.6875431],
-  limit: 2
+  limit: 1
 })
   .send()
   .then(response => {

--- a/docs/services.md
+++ b/docs/services.md
@@ -1113,8 +1113,7 @@ See the [public documentation][191].
 
 ```javascript
 geocodingClient.reverseGeocode({
-  query: [-95.4431142, 33.6875431],
-  limit: 1
+  query: [-95.4431142, 33.6875431]
 })
   .send()
   .then(response => {

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -146,8 +146,7 @@ Geocoding.forwardGeocode = function(config) {
  *
  * @example
  * geocodingClient.reverseGeocode({
- *   query: [-95.4431142, 33.6875431],
- *   limit: 1
+ *   query: [-95.4431142, 33.6875431]
  * })
  *   .send()
  *   .then(response => {

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -147,7 +147,7 @@ Geocoding.forwardGeocode = function(config) {
  * @example
  * geocodingClient.reverseGeocode({
  *   query: [-95.4431142, 33.6875431],
- *   limit: 2
+ *   limit: 1
  * })
  *   .send()
  *   .then(response => {


### PR DESCRIPTION
fixes #321

the reverse geocoding should use a single type if limit > 1. since this is a simple example, let's just not set the limit.