### PR TITLE
fix sprite highres encoding

### DIFF
--- a/lib/helpers/url-utils.js
+++ b/lib/helpers/url-utils.js
@@ -107,10 +107,7 @@ function interpolateRouteParams(route, params) {
     if (value === undefined) {
       throw new Error('Unspecified route parameter ' + paramId);
     }
-    var preppedValue =
-      typeof value === 'string' && value.startsWith('sprite@')
-        ? value
-        : encodeValue(value);
+    var preppedValue = encodeValue(value);
     return '/' + preppedValue;
   });
 }

--- a/lib/helpers/url-utils.js
+++ b/lib/helpers/url-utils.js
@@ -107,7 +107,10 @@ function interpolateRouteParams(route, params) {
     if (value === undefined) {
       throw new Error('Unspecified route parameter ' + paramId);
     }
-    var preppedValue = encodeValue(value);
+    var preppedValue =
+      typeof value === 'string' && value.startsWith('sprite@')
+        ? value
+        : encodeValue(value);
     return '/' + preppedValue;
   });
 }

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -177,11 +177,10 @@ describe('getStyleSprite', () => {
       styleId: 'foo'
     });
     expect(tu.requestConfig(styles)).toEqual({
-      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      path: '/styles/v1/:ownerId/:styleId/sprite.json',
       method: 'GET',
       params: {
-        styleId: 'foo',
-        fileName: 'sprite.json'
+        styleId: 'foo'
       }
     });
   });
@@ -193,11 +192,10 @@ describe('getStyleSprite', () => {
       highRes: true
     });
     expect(tu.requestConfig(styles)).toEqual({
-      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      path: '/styles/v1/:ownerId/:styleId/sprite@2x.json',
       method: 'GET',
       params: {
-        styleId: 'foo',
-        fileName: 'sprite@2x.json'
+        styleId: 'foo'
       }
     });
   });
@@ -208,11 +206,10 @@ describe('getStyleSprite', () => {
       styleId: 'foo'
     });
     expect(tu.requestConfig(styles)).toEqual({
-      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      path: '/styles/v1/:ownerId/:styleId/sprite.png',
       method: 'GET',
       params: {
-        styleId: 'foo',
-        fileName: 'sprite.png'
+        styleId: 'foo'
       },
       encoding: 'binary'
     });
@@ -225,11 +222,10 @@ describe('getStyleSprite', () => {
       highRes: true
     });
     expect(tu.requestConfig(styles)).toEqual({
-      path: '/styles/v1/:ownerId/:styleId/:fileName',
+      path: '/styles/v1/:ownerId/:styleId/sprite@2x.png',
       method: 'GET',
       params: {
-        styleId: 'foo',
-        fileName: 'sprite@2x.png'
+        styleId: 'foo'
       },
       encoding: 'binary'
     });

--- a/services/__tests__/styles.test.js
+++ b/services/__tests__/styles.test.js
@@ -237,11 +237,10 @@ describe('getStyleSprite', () => {
       draft: true
     });
     expect(tu.requestConfig(styles)).toEqual({
-      path: '/styles/v1/:ownerId/:styleId/draft/:fileName',
+      path: '/styles/v1/:ownerId/:styleId/draft/sprite.json',
       method: 'GET',
       params: {
-        styleId: 'foo',
-        fileName: 'sprite.json'
+        styleId: 'foo'
       }
     });
   });

--- a/services/styles.js
+++ b/services/styles.js
@@ -336,16 +336,14 @@ Styles.getStyleSprite = function(config) {
   })(config);
 
   var format = config.format || 'json';
-  var fileName = 'sprite' + (config.highRes ? '@2x' : '') + '.' + format;
+  var fileName = '/sprite' + (config.highRes ? '@2x' : '') + '.' + format;
 
   return this.client.createRequest(
     xtend(
       {
         method: 'GET',
-        path: '/styles/v1/:ownerId/:styleId' + (config.draft ? '/draft' : '') + '/:fileName',
-        params: xtend(pick(config, ['ownerId', 'styleId']), {
-          fileName: fileName
-        })
+        path: '/styles/v1/:ownerId/:styleId' + (config.draft ? '/draft' : '') + fileName,
+        params: pick(config, ['ownerId', 'styleId'])
       },
       format === 'png' ? { encoding: 'binary' } : {}
     )

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -247,11 +247,10 @@ function testSharedInterface(createClient) {
         return client
           .createRequest({
             method: 'GET',
-            path: '/styles/v1/:ownerId/:styleId/:fileName',
+            path: '/styles/v1/:ownerId/:styleId/sprite@2x.png',
             params: {
               ownerId: 'specialguy',
-              styleId: 'Wolf & Friend',
-              fileName: 'sprite@2x.png'
+              styleId: 'Wolf & Friend'
             }
           })
           .send();

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -242,6 +242,27 @@ function testSharedInterface(createClient) {
       });
     });
 
+    test('@2x is not encoded', () => {
+      const sendRequest = () => {
+        return client
+          .createRequest({
+            method: 'GET',
+            path: '/styles/v1/:ownerId/:styleId/:fileName',
+            params: {
+              ownerId: 'specialguy',
+              styleId: 'Wolf & Friend',
+              fileName: 'sprite@2x.png'
+            }
+          })
+          .send();
+      };
+      return server.captureRequest(sendRequest).then(req => {
+        expect(req.path).toBe(
+          `/styles/v1/specialguy/Wolf%20%26%20Friend/sprite@2x.png`
+        );
+      });
+    });
+
     test('multiple params', () => {
       const sendRequest = () => {
         return client


### PR DESCRIPTION
previously requests for highres sprites were failing due to `sprite@2x.png` being url encoded as `%40` which fails when requested via the Mapbox API.