### PR TITLE
Correctly handle arrays containing zero values in appendQueryObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Master
+
+- **Fix:** Ensure that appendQueryObject correctly handles arrays containing falsy values (e.g. for proximity coordinates where lat or lng is 0).
+
 ## 0.10.0
 
 - **Add:** add new parameters to `Tilesets#listTilesets`: `type`, `limit`, `sortBy`, `start` and `visibility`.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1448,7 +1448,7 @@ See the [public documentation][230].
   - `config.language` **[Array][206]&lt;[string][197]>?** Specify the language to use for response text and, for forward geocoding, query result weighting.
      Options are [IETF language tags][233] comprised of a mandatory
      [ISO 639-1 language code][234] and optionally one or more IETF subtags for country or script.
-  - `config.routing` **[boolean][198]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+  - `config.routing` **[boolean][198]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
 
 #### Examples
 
@@ -1517,7 +1517,7 @@ See the [public documentation][235].
      Options are [IETF language tags][233] comprised of a mandatory
      [ISO 639-1 language code][234] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
-  - `config.routing` **[boolean][198]?** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+  - `config.routing` **[boolean][198]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
 
 #### Examples
 

--- a/lib/helpers/__tests__/url-utils.test.js
+++ b/lib/helpers/__tests__/url-utils.test.js
@@ -71,6 +71,14 @@ describe('appendQueryObject', () => {
     ).toBe('/foo/bar?test=one%2Ctwo');
   });
 
+  test('handles arrays with zero values correctly', () => {
+    expect(
+      appendQueryObject('/geocoding/v5/mapbox.places/berlin.json', {
+        proximity: [0, 51.5]
+      })
+    ).toBe('/geocoding/v5/mapbox.places/berlin.json?proximity=0%2C51.5');
+  });
+
   test('skips undefined properties', () => {
     expect(
       appendQueryObject('/foo/bar', {

--- a/lib/helpers/url-utils.js
+++ b/lib/helpers/url-utils.js
@@ -57,7 +57,7 @@ function appendQueryObject(url, queryObject) {
     if (Array.isArray(value)) {
       value = value
         .filter(function(v) {
-          return !!v;
+          return v !== null && v !== undefined;
         })
         .join(',');
     }


### PR DESCRIPTION
Hi there - I ran into a bug when I tried to use a MapboxGeocoder object on a map initialised to a point in London (lng: 0, lat: 51.5). It turned out that after fixing that issue (draft PR here: https://github.com/mapbox/mapbox-gl-geocoder/pull/350) there was also a similar bug in the request that the geocoder triggered from this SDK. I believe this PR will solve it, but please let me know if I should do anything differently here!

Without the change I added, appendQueryObject returns `?proximity=51.5`, which breaks because proximity expects an input with two values, not one. With the change, it correctly returns `?proximity=0%2C51.5`.