### PR TITLE
feat: add 'fresh=true' for getStyle function

### DIFF
--- a/services/styles.js
+++ b/services/styles.js
@@ -23,7 +23,7 @@ var Styles = {};
  * @param {string} [config.ownerId]
  * @param {boolean} [config.metadata] - If true, `mapbox:` specific metadata will be preserved
  * @param {boolean} [config.draft=false] - If `true` will retrieve the draft style, otherwise will retrieve the published style.
- * @param {boolean} [config.fresh=false] - If `true` will bypass the style cache, with a lower rate limit than cached requests.
+ * @param {boolean} [config.fresh=false] - If `true`, will bypass the cached version of the style. Fresh style requests have a lower rate limit than cached requests and may have a higher latency. `fresh=true` should never be used in production or high concurrency environments.
  * @return {MapiRequest}
  *
  * @example

--- a/services/styles.js
+++ b/services/styles.js
@@ -23,6 +23,7 @@ var Styles = {};
  * @param {string} [config.ownerId]
  * @param {boolean} [config.metadata] - If true, `mapbox:` specific metadata will be preserved
  * @param {boolean} [config.draft=false] - If `true` will retrieve the draft style, otherwise will retrieve the published style.
+ * @param {boolean} [config.fresh=false] - If `true` will bypass the style cache, with a lower rate limit than cached requests.
  * @return {MapiRequest}
  *
  * @example
@@ -39,12 +40,16 @@ Styles.getStyle = function(config) {
     styleId: v.required(v.string),
     ownerId: v.string,
     metadata: v.boolean,
-    draft: v.boolean
+    draft: v.boolean,
+    fresh: v.boolean
   })(config);
 
   var query = {};
   if (config.metadata) {
     query.metadata = config.metadata;
+  }
+  if (config.fresh) {
+    query.fresh = 'true';
   }
 
   return this.client.createRequest({


### PR DESCRIPTION
https://github.com/mapbox/mapbox-sdk-js/issues/364

I am in need of fresh=true for previewing changes in the app where we're using a style.

From @samanpwbb 

>    *  Requests that use this param bypass Mapbox's caching, and request times can therefore be quite a bit slower.
>    * Requests that use this param have a significantly lower rate limit than cached requests.
> 
> There are a few valid use-cases for fresh=true, for example, to preview a change in your app if you're co-developing a style and an app at the same time, but it should never be used in production / high concurrency environments.
> 
> Hope this helps clarify things, and we'll get some documentation up around fresh=true soon.