### PR TITLE
support driving-traffic profile in optimization service

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1731,7 +1731,7 @@ to understand all of the available options.
 #### Parameters
 
 - `config` **[Object][197]** 
-  - `config.profile` **(`"driving"` \| `"walking"` \| `"cycling"`)**  (optional, default `"driving"`)
+  - `config.profile` **(`"driving"` \| `"driving-traffic"` \| `"walking"` \| `"cycling"`)**  (optional, default `"driving"`)
   - `config.waypoints` **[Array][207]&lt;[OptimizationWaypoint][245]>** An ordered array of [`OptimizationWaypoint`][177] objects, between 2 and 12 (inclusive).
   - `config.annotations` **[Array][207]&lt;(`"duration"` \| `"distance"` \| `"speed"`)>?** Specify additional metadata that should be returned.
   - `config.destination` **(`"any"` \| `"last"`)** Returned route ends at `any` or `last` coordinate. (optional, default `"any"`)

--- a/services/optimization.js
+++ b/services/optimization.js
@@ -20,7 +20,7 @@ var Optimization = {};
  * to understand all of the available options.
  *
  * @param {Object} config
- * @param {'driving'|'walking'|'cycling'} [config.profile="driving"]
+ * @param {'driving'|'driving-traffic'|'walking'|'cycling'} [config.profile="driving"]
  * @param {Array<OptimizationWaypoint>} config.waypoints - An ordered array of [`OptimizationWaypoint`](#optimizationwaypoint) objects, between 2 and 12 (inclusive).
  * @param {Array<'duration'|'distance'|'speed'>} [config.annotations] - Specify additional metadata that should be returned.
  * @param {'any'|'last'} [config.destination="any"] - Returned route ends at `any` or `last` coordinate.
@@ -36,7 +36,7 @@ var Optimization = {};
  */
 Optimization.getOptimization = function(config) {
   v.assertShape({
-    profile: v.oneOf('driving', 'walking', 'cycling'),
+    profile: v.oneOf('driving', 'driving-traffic', 'walking', 'cycling'),
     waypoints: v.required(
       v.arrayOf(
         v.shape({


### PR DESCRIPTION
closes #366 

Per https://docs.mapbox.com/api/navigation/#optimization `driving-traffic` should be a supported profile.