### PR TITLE
task: update `uploads.createUpload` function params

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -106,6 +106,7 @@ See the [corresponding HTTP service documentation][195].
   - `config.ownerId` **[string][197]?** 
   - `config.metadata` **[boolean][198]?** If true, `mapbox:` specific metadata will be preserved
   - `config.draft` **[boolean][198]** If `true` will retrieve the draft style, otherwise will retrieve the published style. (optional, default `false`)
+  - `config.fresh` **[boolean][198]** If `true`, will bypass the cached version of the style. Fresh style requests have a lower rate limit than cached requests and may have a higher latency. `fresh=true` should never be used in production or high concurrency environments. (optional, default `false`)
 
 #### Examples
 
@@ -632,12 +633,13 @@ See the [corresponding HTTP service documentation][212].
 #### Parameters
 
 - `config` **[Object][196]** 
-  - `config.mapId` **[string][197]** The map ID to create or replace in the format `username.nameoftileset`.
+  - `config.tileset` **[string][197]** The tileset ID to create or replace, in the format `username.nameoftileset`.
       Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
   - `config.url` **[string][197]** Either of the following:-   HTTPS URL of the S3 object provided by [`createUploadCredentials`][39]
     - The `mapbox://` URL of an existing dataset that you'd like to export to a tileset.
       This should be in the format `mapbox://datasets/{username}/{datasetId}`.
-  - `config.tilesetName` **[string][197]?** Name for the tileset. Limited to 64 characters.
+  - `config.name` **[string][197]** Optional. The name of the tileset. Limited to 64 characters.
+  - `config.private` **[boolean][198]** Optional. A boolean that describes whether the tileset must be used with an access token from your Mapbox account. Default is true.
 
 #### Examples
 
@@ -652,8 +654,10 @@ const credentials = {
   url: '{s3 url}'
 };
 uploadsClient.createUpload({
-  mapId: `${myUsername}.${myTileset}`,
-  url: credentials.url
+  titleset: `${myUsername}.${myTileset}`,
+  url: credentials.url,
+  name: 'my uploads name',
+  private: true
 })
   .send()
   .then(response => {

--- a/docs/services.md
+++ b/docs/services.md
@@ -635,11 +635,9 @@ See the [corresponding HTTP service documentation][212].
 - `config` **[Object][196]** 
   - `config.tileset` **[string][197]** The tileset ID to create or replace, in the format `username.nameoftileset`.
       Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
-  - `config.url` **[string][197]** Either of the following:-   HTTPS URL of the S3 object provided by [`createUploadCredentials`][39]
-    - The `mapbox://` URL of an existing dataset that you'd like to export to a tileset.
-      This should be in the format `mapbox://datasets/{username}/{datasetId}`.
-  - `config.name` **[string][197]** Optional. The name of the tileset. Limited to 64 characters.
-  - `config.private` **[boolean][198]** Optional. A boolean that describes whether the tileset must be used with an access token from your Mapbox account. Default is true.
+  - `config.url` **[string][197]** HTTPS URL of the S3 object provided by [`createUploadCredentials`][39]
+  - `config.name` **[string][197]?** The name of the tileset. Limited to 64 characters.
+  - `config.private` **[boolean][198]** A boolean that describes whether the tileset must be used with an access token from your Mapbox account. Default is true. (optional, default `true`)
 
 #### Examples
 

--- a/services/__tests__/uploads.test.js
+++ b/services/__tests__/uploads.test.js
@@ -33,17 +33,57 @@ describe('createUploadCredentials', () => {
 describe('createUpload', () => {
   test('works', () => {
     uploads.createUpload({
-      mapId: 'tilted_towers',
-      url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
-      tilesetName: 'dusty_devote'
+      tileset: 'username.nameoftileset',
+      url: 'http://{bucket}.s3.amazonaws.com/{key}',
+      name: 'dusty_devote',
+      private: false
+    });
+
+    expect(tu.requestConfig(uploads)).toEqual({
+      path: '/uploads/v1/:ownerId',
+      method: 'POST',
+      body: {
+        tileset: 'username.nameoftileset',
+        url: 'http://{bucket}.s3.amazonaws.com/{key}',
+        name: 'dusty_devote',
+        private: false
+      }
+    });
+  });
+
+  test('defaults values', () => {
+    uploads.createUpload({
+      tileset: 'username.nameoftileset',
+      name: 'disty_devote',
+      url: 'http://{bucket}.s3.amazonaws.com/{key}'
     });
     expect(tu.requestConfig(uploads)).toEqual({
       path: '/uploads/v1/:ownerId',
       method: 'POST',
       body: {
+        tileset: 'username.nameoftileset',
+        url: 'http://{bucket}.s3.amazonaws.com/{key}',
+        name: 'disty_devote',
+        private: true
+      }
+    });
+  });
+
+  test('backwards compatibility', () => {
+    uploads.createUpload({
+      mapId: 'tilted_towers',
+      tilesetName: 'dusty_devote',
+      url: 'http://{bucket}.s3.amazonaws.com/{key}'
+    });
+
+    expect(tu.requestConfig(uploads)).toEqual({
+      path: '/uploads/v1/:ownerId',
+      method: 'POST',
+      body: {
         tileset: 'tilted_towers',
-        url: 'mapbox://datasets/kushan2020/cio5g309a004eusknialll02g',
-        name: 'dusty_devote'
+        url: 'http://{bucket}.s3.amazonaws.com/{key}',
+        name: 'dusty_devote',
+        private: true
       }
     });
   });


### PR DESCRIPTION
## Overview
Update `createUpload` parameters to match [updated documentation](https://docs.mapbox.com/api/maps/#create-an-upload). Supports backwards compatibility.

- `config.mapId` will overwrite `config.tileset` if set
- `config.tilesetName` will overwrite `config.name` if set


### Changed
- Add keys to config object passed into `createUpload`
  - tileset
  - name
  - private

- Update request body for `createUpload`
```js
// before
requestBody = {
  tileset: config.mapId,
  url: config.url,
  name: config.titlesetName
}

// after
requestBody = {
  tileset: config.titleset,
  url: config.url,
  name: config.name,
  private: config.private // defaults to true if not set
}
```

closes #336