### PR TITLE
downgrade fusspot to 0.4.0 to fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
       }
     },
     "@mapbox/fusspot": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.7.2.tgz",
-      "integrity": "sha512-mt6h3N2FPyqCRixqFL/cfy6X8jx4eHqwJvPMzDoWZ2TbpWaE4Y0xC3zFeG40KDFgjJ3NYg13Xy9/ZJcZY32vLg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.4.0.tgz",
+      "integrity": "sha512-6sys1vUlhNCqMvJOqPEPSi0jc9tg7aJ//oG1A16H3PXoIt9whtNngD7UzBHUVTH15zunR/vRvMtGNVsogm1KzA==",
       "requires": {
         "is-plain-obj": "^1.1.0",
         "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@mapbox/fusspot": "^0.7.0",
+    "@mapbox/fusspot": "^0.4.0",
     "@mapbox/parse-mapbox-token": "^0.2.0",
     "@mapbox/polyline": "^1.0.0",
     "eventemitter3": "^3.1.0",


### PR DESCRIPTION
fixes #380

#368 included an upgrade to fusspot, originally to use `v.objectOf` which was only introduced in a later version, however in the end that PR didn't end up using `v.objectOf` so for now as a quick fix we can revert back to fusspot 0.4.0.

After this we can then work out the best approach to importing modules which use `const`.