### PR TITLE
Allow the client to work inside a web worker

### DIFF
--- a/lib/browser/browser-layer.js
+++ b/lib/browser/browser-layer.js
@@ -102,7 +102,11 @@ function sendRequestXhr(request, xhr) {
 // for Mapbox's internal client.
 function createRequestXhr(request, accessToken) {
   var url = request.url(accessToken);
-  var xhr = new window.XMLHttpRequest();
+  
+  // eslint-disable-next-line no-restricted-globals
+  const context = typeof window !== "undefined" ? window : self;
+  var xhr = new context.XMLHttpRequest();
+  
   xhr.open(request.method, url);
   Object.keys(request.headers).forEach(function(key) {
     xhr.setRequestHeader(key, request.headers[key]);


### PR DESCRIPTION
Hi,

Currently this sdk doesn't work when you call methods from inside a webworker.
This is because a worker doesn't have access to the window object. In a WorkerGlobalScope you have to use "self" instead of window. 

This only requires 1-2 lines of code to be changed.

Kind regards,
Marnix