### PR TITLE
Migrate to Travis CI .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @mapbox/mapbox-sdk
 
+[![Build Status](https://travis-ci.com/mapbox/mapbox-sdk-js.svg?branch=main)](https://travis-ci.com/mapbox/mapbox-sdk-js)
+
 A JS SDK for working with [Mapbox APIs](https://docs.mapbox.com/api/).
 
 Works in Node, the browser, and React Native.


### PR DESCRIPTION
I migrated this repo off of Travis CI org and on to Travis CI com. This PR adds the Travis badge.