### PR TITLE
Removing "private" from "createUpload"

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -643,7 +643,6 @@ See the [corresponding HTTP service documentation][218].
       Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
   - `config.url` **[string][201]** HTTPS URL of the S3 object provided by [`createUploadCredentials`][39]
   - `config.name` **[string][201]?** The name of the tileset. Limited to 64 characters.
-  - `config.private` **[boolean][202]** A boolean that describes whether the tileset must be used with an access token from your Mapbox account. Default is true. (optional, default `true`)
 
 #### Examples
 
@@ -661,7 +660,6 @@ uploadsClient.createUpload({
   titleset: `${myUsername}.${myTileset}`,
   url: credentials.url,
   name: 'my uploads name',
-  private: true
 })
   .send()
   .then(response => {

--- a/services/__tests__/uploads.test.js
+++ b/services/__tests__/uploads.test.js
@@ -35,8 +35,7 @@ describe('createUpload', () => {
     uploads.createUpload({
       tileset: 'username.nameoftileset',
       url: 'http://{bucket}.s3.amazonaws.com/{key}',
-      name: 'dusty_devote',
-      private: false
+      name: 'dusty_devote'
     });
 
     expect(tu.requestConfig(uploads)).toEqual({
@@ -45,8 +44,7 @@ describe('createUpload', () => {
       body: {
         tileset: 'username.nameoftileset',
         url: 'http://{bucket}.s3.amazonaws.com/{key}',
-        name: 'dusty_devote',
-        private: false
+        name: 'dusty_devote'
       }
     });
   });
@@ -63,8 +61,7 @@ describe('createUpload', () => {
       body: {
         tileset: 'username.nameoftileset',
         url: 'http://{bucket}.s3.amazonaws.com/{key}',
-        name: 'disty_devote',
-        private: true
+        name: 'disty_devote'
       }
     });
   });
@@ -82,8 +79,7 @@ describe('createUpload', () => {
       body: {
         tileset: 'tilted_towers',
         url: 'http://{bucket}.s3.amazonaws.com/{key}',
-        name: 'dusty_devote',
-        private: true
+        name: 'dusty_devote'
       }
     });
   });

--- a/services/uploads.js
+++ b/services/uploads.js
@@ -88,7 +88,6 @@ Uploads.createUploadCredentials = function() {
  *   Limited to 32 characters (only `-` and `_` special characters allowed; limit does not include username).
  * @param {string} config.url - HTTPS URL of the S3 object provided by [`createUploadCredentials`](#createuploadcredentials)
  * @param {string} [config.name] - The name of the tileset. Limited to 64 characters.
- * @param {boolean} [config.private=true] - A boolean that describes whether the tileset must be used with an access token from your Mapbox account. Default is true.
  * @return {MapiRequest}
  *
  * @example
@@ -105,7 +104,6 @@ Uploads.createUploadCredentials = function() {
  *   titleset: `${myUsername}.${myTileset}`,
  *   url: credentials.url,
  *   name: 'my uploads name',
- *   private: true
  * })
  *   .send()
  *   .then(response => {
@@ -117,7 +115,6 @@ Uploads.createUpload = function(config) {
     url: v.required(v.string),
     tileset: v.string,
     name: v.string,
-    private: v.boolean,
     mapId: v.string,
     tilesetName: v.string
   })(config);
@@ -140,14 +137,10 @@ Uploads.createUpload = function(config) {
     config.name = config.tilesetName;
   }
 
-  if (config.private !== false) {
-    config.private = true;
-  }
-
   return this.client.createRequest({
     method: 'POST',
     path: '/uploads/v1/:ownerId',
-    body: pick(config, ['tileset', 'url', 'name', 'private'])
+    body: pick(config, ['tileset', 'url', 'name'])
   });
 };
 


### PR DESCRIPTION
Based on https://github.com/mapbox/mapbox-sdk-js/issues/392

```
MapiError {
  message: 'The request body contains the invalid property "private".',
  type: 'HttpError',
  statusCode: 422,
  request: MapiRequest {
    id: 1,
    _options: { method: 'POST', path: '/uploads/v1/:ownerId', body: [Object] },
    emitter: EventEmitter {
      _events: Events <Complex prototype> {},
      _eventsCount: 0
    },
    client: NodeClient {
      accessToken: '{accessToken}',
      origin: 'https://api.mapbox.com'
    },
    response: null,
    error: [Circular],
    sent: true,
    aborted: false,
    path: '/uploads/v1/:ownerId',
    method: 'POST',
    origin: 'https://api.mapbox.com',
    query: {},
    params: {},
    body: {
      tileset: '{username}.{name},
      url: '{url}',
      name: 'Random Name,
      private: true
    },
    file: null,
    encoding: 'utf8',
    sendFileAs: null,
    headers: { 'content-type': 'application/json' }
  },
  body: {
    message: 'The request body contains the invalid property "private".'
  }
}
```

I removed all of the instances of the use "private" and updated the tests.

Tested the request without private and the API was successful.