### PR TITLE
Fixes #412

### DIFF
--- a/services/static.js
+++ b/services/static.js
@@ -431,7 +431,7 @@ function encodePathOverlay(o) {
   }
   // polyline expects each coordinate to be in reversed order: [lat, lng]
   var reversedCoordinates = o.coordinates.map(function(c) {
-    return c.reverse();
+    return [c[1], c[0]];
   });
   var encodedPolyline = polyline.encode(reversedCoordinates);
   result += '(' + encodeURIComponent(encodedPolyline) + ')';


### PR DESCRIPTION
Array.prototype.reverse() reverses an array _in place_. This results in the unintended mutation of the coordinates property of encodePathOverlay()'s o (overlay) param. See a side-effect of this mutation in #412. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse

Instead, create a new array and initialize it with the reversed lat and long.
