### PR TITLE
Add driving-traffic profile to Isochrone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- **Add:** add `driving-traffic` profile to Isochrone service.
+
 ## 0.12.1
+
 - **PATCH:** [remove unsupported `private` option](https://github.com/mapbox/mapbox-sdk-js/pull/405) from `createUpload`.   
 
 ## 0.12.0

--- a/docs/services.md
+++ b/docs/services.md
@@ -2129,7 +2129,7 @@ Given a location and a routing profile, retrieve up to four isochrone contours
 #### Parameters
 
 - `config` **[Object][200]** 
-  - `config.profile` **(`"driving"` \| `"walking"` \| `"cycling"`)**     A Mapbox Directions routing profile ID. (optional, default `"driving"`)
+  - `config.profile` **(`"driving"` \| `"walking"` \| `"cycling"` \| `"driving-traffic"`)**     A Mapbox Directions routing profile ID. (optional, default `"driving"`)
   - `config.coordinates` **[Coordinates][232]** A  {longitude,latitude} coordinate pair around which to center the isochrone lines.
   - `config.minutes` **[Array][210]&lt;[number][205]>** The times in minutes to use for each isochrone contour. You can specify up to four contours. Times must be in increasing order. The maximum time that can be specified is 60 minutes.
   - `config.colors` **[Array][210]&lt;[string][201]>?** The colors to use for each isochrone contour, specified as hex values without a leading # (for example, ff0000 for red). If this parameter is used, there must be the same number of colors as there are entries in contours_minutes. If no colors are specified, the Isochrone API will assign a default rainbow color scheme to the output.

--- a/services/__tests__/isochrone.test.js
+++ b/services/__tests__/isochrone.test.js
@@ -28,6 +28,26 @@ describe('getContours', () => {
       }
     });
   });
+  
+  test('works, driving-traffic', () => {
+    isochrone.getContours({
+      coordinates: [-118.22258, 33.99038],
+      minutes: [5, 10, 15],
+      profile: 'driving-traffic'
+    });
+
+    expect(tu.requestConfig(isochrone)).toEqual({
+      path: '/isochrone/v1/mapbox/:profile/:coordinates',
+      method: 'GET',
+      params: {
+        coordinates: '-118.22258,33.99038',
+        profile: 'driving-traffic'
+      },
+      query: {
+        contours_minutes: '5,10,15'
+      }
+    });
+  });
 
   test('it omits queries not supplied', () => {
     isochrone.getContours({

--- a/services/isochrone.js
+++ b/services/isochrone.js
@@ -16,7 +16,7 @@ var Isochrone = {};
 /**
  * Given a location and a routing profile, retrieve up to four isochrone contours
  * @param {Object} config
- * @param {'driving'|'walking'|'cycling'} [config.profile="driving"] - 	A Mapbox Directions routing profile ID.
+ * @param {'driving'|'walking'|'cycling'|'driving-traffic'} [config.profile="driving"] - 	A Mapbox Directions routing profile ID.
  * @param {Coordinates} config.coordinates - A  {longitude,latitude} coordinate pair around which to center the isochrone lines.
  * @param {Array<number>} config.minutes - The times in minutes to use for each isochrone contour. You can specify up to four contours. Times must be in increasing order. The maximum time that can be specified is 60 minutes.
  * @param {Array<string>} [config.colors] - The colors to use for each isochrone contour, specified as hex values without a leading # (for example, ff0000 for red). If this parameter is used, there must be the same number of colors as there are entries in contours_minutes. If no colors are specified, the Isochrone API will assign a default rainbow color scheme to the output.
@@ -28,7 +28,7 @@ var Isochrone = {};
  */
 Isochrone.getContours = function(config) {
   v.assertShape({
-    profile: v.oneOf('driving', 'walking', 'cycling'),
+    profile: v.oneOf('driving', 'walking', 'cycling', 'driving-traffic'),
     coordinates: v.coordinates,
     minutes: v.arrayOf(v.number),
     colors: v.arrayOf(v.string),


### PR DESCRIPTION
This PR adds the `driving-traffic` profile to the Isochrone service.

@danpat for review.