### PR TITLE
Added parameters to geocoding service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Revert:** add `driving-traffic` profile to Isochrone service.
 
+## 0.13.2
+
+**Add:** add `fuzzyMatch` and `worldview` parameters to the geocoding service
+
 ## 0.13.1
 
 **Fix:** Update `got` depdendency to 10.7.0

--- a/docs/services.md
+++ b/docs/services.md
@@ -1524,7 +1524,7 @@ See the [public documentation][236].
      [ISO 639-1 language code][240] and optionally one or more IETF subtags for country or script.
   - `config.routing` **[boolean][202]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
   - `config.fuzzyMatch` **[boolean][202]** Specify whether the Geocoding API should attempt approximate, as well as exact, matching. (optional, default `true`)
-  - `config.worldview` **(`"cn"` \| `"in"` \| `"jp"` \| `"us"`)?** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+  - `config.worldview` **[String][201]** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups. (optional, default `"us"`)
 
 #### Examples
 
@@ -1594,7 +1594,7 @@ See the [public documentation][241].
      [ISO 639-1 language code][240] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
   - `config.routing` **[boolean][202]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
-  - `config.worldview` **(`"cn"` \| `"in"` \| `"jp"` \| `"us"`)?** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+  - `config.worldview` **[String][201]** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups. (optional, default `"us"`)
 
 #### Examples
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1523,6 +1523,8 @@ See the [public documentation][236].
      Options are [IETF language tags][239] comprised of a mandatory
      [ISO 639-1 language code][240] and optionally one or more IETF subtags for country or script.
   - `config.routing` **[boolean][202]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
+  - `config.fuzzyMatch` **[boolean][202]** Specify whether the Geocoding API should attempt approximate, as well as exact, matching. (optional, default `true`)
+  - `config.worldview` **(`"cn"` \| `"in"` \| `"jp"` \| `"us"`)?** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
 
 #### Examples
 
@@ -1592,6 +1594,7 @@ See the [public documentation][241].
      [ISO 639-1 language code][240] and optionally one or more IETF subtags for country or script.
   - `config.reverseMode` **(`"distance"` \| `"score"`)** Set the factors that are used to sort nearby results. (optional, default `'distance'`)
   - `config.routing` **[boolean][202]** Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features. (optional, default `false`)
+  - `config.worldview` **(`"cn"` \| `"in"` \| `"jp"` \| `"us"`)?** Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
 
 #### Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.0",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.2",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.2",
+  "version": "0.13.1",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/services/__tests__/geocoding.test.js
+++ b/services/__tests__/geocoding.test.js
@@ -35,7 +35,9 @@ describe('forwardGeocode', () => {
       bbox: [1, 2, 3, 4],
       limit: 3,
       language: ['de', 'bs'],
-      routing: true
+      routing: true,
+      fuzzyMatch: true,
+      worldview: 'us'
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',
@@ -52,7 +54,9 @@ describe('forwardGeocode', () => {
         bbox: [1, 2, 3, 4],
         limit: 3,
         language: ['de', 'bs'],
-        routing: 'true'
+        routing: 'true',
+        fuzzyMatch: 'true',
+        worldview: 'us'
       }
     });
   });
@@ -84,7 +88,8 @@ describe('reverseGeocode', () => {
       limit: 3,
       language: ['de', 'bs'],
       reverseMode: 'distance',
-      routing: true
+      routing: true,
+      worldview: 'us'
     });
     expect(tu.requestConfig(geocoding)).toEqual({
       method: 'GET',
@@ -100,7 +105,8 @@ describe('reverseGeocode', () => {
         limit: 3,
         language: ['de', 'bs'],
         reverseMode: 'distance',
-        routing: 'true'
+        routing: 'true',
+        worldview: 'us'
       }
     });
   });

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -46,6 +46,8 @@ var featureTypes = [
  *  Options are [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) comprised of a mandatory
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+ * @param {boolean} [config.fuzzyMatch=true] - Specify whether the Geocoding API should attempt approximate, as well as exact, matching.
+ * @param {'cn'|'in'|'jp'|'us'} [config.worldview] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @return {MapiRequest}
  *
  * @example
@@ -100,7 +102,9 @@ Geocoding.forwardGeocode = function(config) {
     bbox: v.arrayOf(v.number),
     limit: v.number,
     language: v.arrayOf(v.string),
-    routing: v.boolean
+    routing: v.boolean,
+    fuzzyMatch: v.boolean,
+    worldview: v.string
   })(config);
 
   config.mode = config.mode || 'mapbox.places';
@@ -115,7 +119,9 @@ Geocoding.forwardGeocode = function(config) {
         'bbox',
         'limit',
         'language',
-        'routing'
+        'routing',
+        'fuzzyMatch',
+        'worldview'
       ])
     )
   );
@@ -146,6 +152,7 @@ Geocoding.forwardGeocode = function(config) {
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {'distance'|'score'} [config.reverseMode='distance'] - Set the factors that are used to sort nearby results.
  * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
+ * @param {'cn'|'in'|'jp'|'us'} [config.worldview] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @return {MapiRequest}
  *
  * @example
@@ -168,7 +175,8 @@ Geocoding.reverseGeocode = function(config) {
     limit: v.number,
     language: v.arrayOf(v.string),
     reverseMode: v.oneOf('distance', 'score'),
-    routing: v.boolean
+    routing: v.boolean,
+    worldview: v.string
   })(config);
 
   config.mode = config.mode || 'mapbox.places';
@@ -183,7 +191,8 @@ Geocoding.reverseGeocode = function(config) {
         'limit',
         'language',
         'reverseMode',
-        'routing'
+        'routing',
+        'worldview'
       ])
     )
   );

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -47,7 +47,7 @@ var featureTypes = [
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
  * @param {boolean} [config.fuzzyMatch=true] - Specify whether the Geocoding API should attempt approximate, as well as exact, matching.
- * @param {'cn'|'in'|'jp'|'us'} [config.worldview] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+ * @param {String} [config.worldview="us"] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @return {MapiRequest}
  *
  * @example
@@ -152,7 +152,7 @@ Geocoding.forwardGeocode = function(config) {
  *  [ISO 639-1 language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and optionally one or more IETF subtags for country or script.
  * @param {'distance'|'score'} [config.reverseMode='distance'] - Set the factors that are used to sort nearby results.
  * @param {boolean} [config.routing=false] - Specify whether to request additional metadata about the recommended navigation destination. Only applicable for address features.
- * @param {'cn'|'in'|'jp'|'us'} [config.worldview] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
+ * @param {String} [config.worldview="us"] - Filter results to geographic features whose characteristics are defined differently by audiences belonging to various regional, cultural, or political groups.
  * @return {MapiRequest}
  *
  * @example


### PR DESCRIPTION
Added the following parameters which were missing from the SDK:

[ forwardGeocode ]:
- `fuzzyMatch`
- `worldview`

[ reverseGeocode ]:
- `worldview`

cc: @mapbox-danny 