### PR TITLE
Add 'ip' as valid value for geocoding proximity parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - **Revert:** add `driving-traffic` profile to Isochrone service.
 
+## 0.13.3
+
+**Add:** add `ip` as valid value for `proximity` parameter in the geocoding service
+
 ## 0.13.2
 
 **Add:** add `fuzzyMatch` and `worldview` parameters to the geocoding service

--- a/docs/services.md
+++ b/docs/services.md
@@ -1514,7 +1514,7 @@ See the [public documentation][236].
   - `config.mode` **(`"mapbox.places"` \| `"mapbox.places-permanent"`)** Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding. (optional, default `"mapbox.places"`)
   - `config.countries` **[Array][210]&lt;[string][201]>?** Limits results to the specified countries.
       Each item in the array should be an [ISO 3166 alpha 2 country code][237].
-  - `config.proximity` **[Coordinates][232]?** Bias local results based on a provided location.
+  - `config.proximity` **([Coordinates][232] \| `"ip"`)?** Bias local results based on a provided coordinate location or a user's IP address.
   - `config.types` **[Array][210]&lt;(`"country"` \| `"region"` \| `"postcode"` \| `"district"` \| `"place"` \| `"locality"` \| `"neighborhood"` \| `"address"` \| `"poi"` \| `"poi.landmark"`)>?** Filter results by feature types.
   - `config.autocomplete` **[boolean][202]** Return autocomplete results or not. (optional, default `true`)
   - `config.bbox` **[BoundingBox][238]?** Limit results to a bounding box.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/services/geocoding.js
+++ b/services/geocoding.js
@@ -37,7 +37,7 @@ var featureTypes = [
  * @param {'mapbox.places'|'mapbox.places-permanent'} [config.mode="mapbox.places"] - Either `mapbox.places` for ephemeral geocoding, or `mapbox.places-permanent` for storing results and batch geocoding.
  * @param {Array<string>} [config.countries] - Limits results to the specified countries.
  *   Each item in the array should be an [ISO 3166 alpha 2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
- * @param {Coordinates} [config.proximity] - Bias local results based on a provided location.
+ * @param {Coordinates|'ip'} [config.proximity] - Bias local results based on a provided coordinate location or a user's IP address.
  * @param {Array<'country'|'region'|'postcode'|'district'|'place'|'locality'|'neighborhood'|'address'|'poi'|'poi.landmark'>} [config.types] - Filter results by feature types.
  * @param {boolean} [config.autocomplete=true] - Return autocomplete results or not.
  * @param {BoundingBox} [config.bbox] - Limit results to a bounding box.
@@ -96,7 +96,7 @@ Geocoding.forwardGeocode = function(config) {
     query: v.required(v.string),
     mode: v.oneOf('mapbox.places', 'mapbox.places-permanent'),
     countries: v.arrayOf(v.string),
-    proximity: v.coordinates,
+    proximity: v.oneOf(v.coordinates, 'ip'),
     types: v.arrayOf(v.oneOf(featureTypes)),
     autocomplete: v.boolean,
     bbox: v.arrayOf(v.number),


### PR DESCRIPTION
Enables usage of `"ip"` as a valid `proximity` parameter value on the geocoding service, bringing it into alignment with a recent update on the [Geocoding API](https://docs.mapbox.com/api/search/geocoding/#forward-geocoding).