### PR TITLE
fix tests after got version bump

### DIFF
--- a/test/node-interface.test.js
+++ b/test/node-interface.test.js
@@ -63,7 +63,7 @@ describe('test node progress events', () => {
     return request.send().then(() => {
       expect(progressUpload).toEqual([
         { percent: 0, total: undefined, transferred: 0 },
-        { percent: 100, total: undefined, transferred: 0 }
+        { percent: 100, total: 0, transferred: 0 }
       ]);
     });
   });

--- a/test/test-shared-interface.js
+++ b/test/test-shared-interface.js
@@ -149,12 +149,16 @@ function testSharedInterface(createClient) {
     });
 
     const sendRequest = method => {
-      return client
-        .createRequest({
-          method,
-          path: '/foodstuffs/v1/:ownerId'
-        })
-        .send();
+      const requestParams = {
+        method,
+        path: '/foodstuffs/v1/:ownerId'
+      };
+
+      if (method === 'DELETE') {
+        requestParams.body = {};
+      }
+
+      return client.createRequest(requestParams).send();
     };
 
     test('GET', () => {


### PR DESCRIPTION
Fixes two tests that broke after #440 was merged:

- `DELETE` request requires a body
- `progressUpload` returns a `0` instead of `undefined`