### PR TITLE
Add support for allowedApplications to Tokens.createToken and Tokens.updateToken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: node_js
 node_js:
   - lts/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Add:** Config for `Tokens#createToken` and `Tokens#updateToken` can now include the `allowedApplications` property.
+
+
 ## 0.13.7
 
 - **Add:** add additional EV values to the directions API request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.14.0
+
 - **Add:** Config for `Tokens#createToken` and `Tokens#updateToken` can now include the `allowedApplications` property.
 
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -2028,6 +2028,7 @@ See the [corresponding HTTP service documentation][246].
     *   `config.scopes` **[Array][209]<[string][201]>?**&#x20;
     *   `config.resources` **[Array][209]<[string][201]>?**&#x20;
     *   `config.allowedUrls` **[Array][209]<[string][201]>?**&#x20;
+    *   `config.allowedApplications` **[Array][209]<{platform: [string][201], bundleId: [string][201]}>?** This option restricts tokens with an Application Bundle ID. The feature is in beta and is only available to our selected customers.  For more information, please contact sales.
 
 #### Examples
 
@@ -2085,7 +2086,8 @@ See the [corresponding HTTP service documentation][248].
     *   `config.note` **[string][201]?**&#x20;
     *   `config.scopes` **[Array][209]<[string][201]>?**&#x20;
     *   `config.resources` **[Array][209]<[string][201]>?**&#x20;
-    *   `config.allowedUrls` **[Array][209]<[string][201]>?**&#x20;
+    *   `config.allowedUrls` **([Array][209]<[string][201]> | null)?**&#x20;
+    *   `config.allowedApplications` **([Array][209]<{platform: [string][201], bundleId: [string][201]}> | null)?** This option restricts tokens with an Application Bundle ID. The feature is in beta and is only available to our selected customers.  For more information, please contact sales.
 
 #### Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.7",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-sdk",
-      "version": "0.13.7",
+      "version": "0.14.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.13.7",
+  "version": "0.14.0",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/services/__tests__/tokens.test.js
+++ b/services/__tests__/tokens.test.js
@@ -73,6 +73,21 @@ describe('createToken', () => {
     });
   });
 
+  test('with allowedApplications', () => {
+    tokens.createToken({
+      allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
+    });
+    expect(tu.requestConfig(tokens)).toEqual({
+      path: '/tokens/v2/:ownerId',
+      method: 'POST',
+      params: {},
+      body: {
+        allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }],
+        scopes: []
+      }
+    });
+  });
+
   test('with scopes', () => {
     tokens.createToken({ scopes: ['styles:read', 'styles:write'] });
     expect(tu.requestConfig(tokens)).toEqual({
@@ -88,7 +103,8 @@ describe('createToken', () => {
       scopes: ['styles:list'],
       note: 'horseleg',
       resources: ['one', 'two'],
-      allowedUrls: ['boba.com', 'coffee.ca']
+      allowedUrls: ['boba.com', 'coffee.ca'],
+      allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId',
@@ -98,7 +114,8 @@ describe('createToken', () => {
         scopes: ['styles:list'],
         note: 'horseleg',
         resources: ['one', 'two'],
-        allowedUrls: ['boba.com', 'coffee.ca']
+        allowedUrls: ['boba.com', 'coffee.ca'],
+        allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
       }
     });
   });
@@ -215,6 +232,37 @@ describe('updateToken', () => {
     });
   });
 
+  test('with allowedApplications', () => {
+    tokens.updateToken({
+      tokenId: 'foo',
+      allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
+    });
+
+    expect(tu.requestConfig(tokens)).toEqual({
+      path: '/tokens/v2/:ownerId/:tokenId',
+      params: { tokenId: 'foo' },
+      method: 'PATCH',
+      body: {
+        allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
+      }
+    });
+  });
+
+  test('allowedApplications can be null', () => {
+    tokens.updateToken({
+      tokenId: 'foo',
+      allowedApplications: null
+    });
+
+    expect(tu.requestConfig(tokens)).toEqual({
+      path: '/tokens/v2/:ownerId/:tokenId',
+      params: { tokenId: 'foo' },
+      method: 'PATCH',
+      body: {
+        allowedApplications: null
+      }
+    });
+  });
 
   test('with scopes', () => {
     tokens.updateToken({
@@ -235,7 +283,8 @@ describe('updateToken', () => {
       scopes: ['styles:list'],
       note: 'horseleg',
       resources: ['one', 'two'],
-      allowedUrls: ['boba.com', 'milk-tea.ca']
+      allowedUrls: ['boba.com', 'milk-tea.ca'],
+      allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
     });
     expect(tu.requestConfig(tokens)).toEqual({
       path: '/tokens/v2/:ownerId/:tokenId',
@@ -245,7 +294,8 @@ describe('updateToken', () => {
         scopes: ['styles:list'],
         note: 'horseleg',
         resources: ['one', 'two'],
-        allowedUrls: ['boba.com', 'milk-tea.ca']
+        allowedUrls: ['boba.com', 'milk-tea.ca'],
+        allowedApplications: [{ platform: 'iOS', bundleId: 'com.example.foo' }]
       }
     });
   });

--- a/services/tokens.js
+++ b/services/tokens.js
@@ -43,6 +43,7 @@ Tokens.listTokens = function() {
  * @param {Array<string>} [config.scopes]
  * @param {Array<string>} [config.resources]
  * @param {Array<string>} [config.allowedUrls]
+ * @param {Array<{ platform: string, bundleId: string }>} [config.allowedApplications] This option restricts tokens with an Application Bundle ID. The feature is in beta and is only available to our selected customers.  For more information, please contact sales.
  * @return {MapiRequest}
  *
  * @example
@@ -61,7 +62,13 @@ Tokens.createToken = function(config) {
     note: v.string,
     scopes: v.arrayOf(v.string),
     resources: v.arrayOf(v.string),
-    allowedUrls: v.arrayOf(v.string)
+    allowedUrls: v.arrayOf(v.string),
+    allowedApplications: v.arrayOf(
+      v.shape({
+        bundleId: v.string,
+        platform: v.string
+      })
+    )
   })(config);
 
   var body = {};
@@ -74,6 +81,10 @@ Tokens.createToken = function(config) {
   }
   if (config.allowedUrls) {
     body.allowedUrls = config.allowedUrls;
+  }
+
+  if (config.allowedApplications) {
+    body.allowedApplications = config.allowedApplications;
   }
 
   return this.client.createRequest({
@@ -130,7 +141,8 @@ Tokens.createTemporaryToken = function(config) {
  * @param {string} [config.note]
  * @param {Array<string>} [config.scopes]
  * @param {Array<string>} [config.resources]
- * @param {Array<string>} [config.allowedUrls]
+ * @param {Array<string> | null} [config.allowedUrls]
+ * @param {Array<{ platform: string, bundleId: string }> | null} [config.allowedApplications] This option restricts tokens with an Application Bundle ID. The feature is in beta and is only available to our selected customers.  For more information, please contact sales.
  * @return {MapiRequest}
  *
  * @example
@@ -150,7 +162,13 @@ Tokens.updateToken = function(config) {
     note: v.string,
     scopes: v.arrayOf(v.string),
     resources: v.arrayOf(v.string),
-    allowedUrls: v.arrayOf(v.string)
+    allowedUrls: v.arrayOf(v.string),
+    allowedApplications: v.arrayOf(
+      v.shape({
+        bundleId: v.string,
+        platform: v.string
+      })
+    )
   })(config);
 
   var body = {};
@@ -165,6 +183,10 @@ Tokens.updateToken = function(config) {
   }
   if (config.allowedUrls || config.allowedUrls === null) {
     body.allowedUrls = config.allowedUrls;
+  }
+
+  if (config.allowedApplications || config.allowedApplications === null) {
+    body.allowedApplications = config.allowedApplications;
   }
 
   return this.client.createRequest({


### PR DESCRIPTION
Adds support for the new `allowedApplications` restriction to `Tokens.createToken` and `Tokens.updateToken` 