### PR TITLE
set body to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.15.4
+
+- **Fix:** Set `body = ''` for POST, PUT, PATCH, and DELETE requests that do not have a body [#479](https://github.com/mapbox/mapbox-sdk-js/pull/479)
+
 ## 0.15.3
 
 - **Fix:** Maximum Optimization V1 request size limits should not be enforced client-side

--- a/lib/node/node-layer.js
+++ b/lib/node/node-layer.js
@@ -60,6 +60,13 @@ function createRequestStreams(request) {
     gotOptions.body = JSON.stringify(request.body);
   }
 
+  if (
+    ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method) &&
+    !request.body
+  ) {
+    gotOptions.body = '';
+  }
+
   var gotStream = got.stream(url, gotOptions);
 
   gotStream.setEncoding(request.encoding);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.4-dev.1",
+  "version": "0.15.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-sdk",
-      "version": "0.15.4-dev.1",
+      "version": "0.15.4",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.3",
+  "version": "0.15.4-dev.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-sdk",
-      "version": "0.15.3",
+      "version": "0.15.4-dev.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.4-dev.1",
+  "version": "0.15.4",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.4",
+  "version": "0.15.4-dev.1",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
A POST, PUT, PATCH, or DELETE request using [got](https://github.com/sindresorhus/got) that does not have a body defined will result in a socket timeout as described in #459. This updates the node-interface to set the body to an empty string if none is provided for the relevant methods.

Resolves #459 

Refs: https://github.com/sindresorhus/got/issues/2303

I've added a regression test that will result in a timeout if the body is not set properly - here's how it looks prior to the change:

![Screen Shot 2024-03-11 at 4 09 18 PM](https://github.com/mapbox/mapbox-sdk-js/assets/1943001/eb88d8fa-bfc1-467d-9bd3-a673f3457e80)
