### PR TITLE
change max_speed annotation to maxspeed

### DIFF
--- a/services/directions.js
+++ b/services/directions.js
@@ -99,7 +99,7 @@ Directions.getDirections = function(config) {
         'speed',
         'congestion',
         'congestion_numeric',
-        'max_speed',
+        'maxspeed',
         'closure',
         'state_of_charge'
       )


### PR DESCRIPTION
Updates the `max_speed` annotation parameter on the directions api, which was recently changed to `maxspeed`