### PR TITLE
Add secondary_address to Geocoding v6 types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.15.6
+
+- **Fix:** Add `secondary_address` to list of accepted types for Geocoding v6
+
 ## 0.15.5
 
 - **Fix:** Rename directions api annotation option `max_speed` to `maxspeed` [#480](https://github.com/mapbox/mapbox-sdk-js/pull/480)

--- a/docs/services.md
+++ b/docs/services.md
@@ -2361,7 +2361,7 @@ See the [public documentation][264].
         Each item in the array should be an [ISO 3166 alpha 2 country code][242].
         \[OR] if used with input mode="structured" denotes single country in free form.
     *   `config.proximity` **([Coordinates][191] | `"ip"`)?** Bias local results based on a provided coordinate location or a user's IP address.
-    *   `config.types` **[Array][216]<(`"street"` | `"country"` | `"region"` | `"postcode"` | `"district"` | `"place"` | `"locality"` | `"neighborhood"` | `"address"`)>?** Filter results by feature types.
+    *   `config.types` **[Array][216]<(`"street"` | `"country"` | `"region"` | `"postcode"` | `"district"` | `"place"` | `"locality"` | `"neighborhood"` | `"address"` | `"secondary_address"`)>?** Filter results by feature types.
     *   `config.bbox` **[BoundingBox][192]?** Limit results to a bounding box.
     *   `config.limit` **[number][212]** Limit the number of results returned. (optional, default `5`)
     *   `config.format` **(`"geojson"` | `"v5"`)** Specify the desired response format of results (geojson, default) or for backwards compatibility (v5). (optional, default `'geojson'`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/mapbox-sdk",
-      "version": "0.15.5",
+      "version": "0.15.6",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-sdk",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "JS SDK for accessing Mapbox APIs",
   "main": "index.js",
   "files": [

--- a/services/__tests__/geocoding-v6.test.js
+++ b/services/__tests__/geocoding-v6.test.js
@@ -26,7 +26,7 @@ describe('forwardGeocode', () => {
       mode: 'standard',
       countries: ['AO', 'AR'],
       proximity: [3, 4],
-      types: ['street', 'country', 'region'],
+      types: ['street', 'country', 'region', 'address', 'secondary_address'],
       autocomplete: true,
       bbox: [1, 2, 3, 4],
       format: 'v5',
@@ -53,7 +53,7 @@ describe('forwardGeocode', () => {
         q: 'Tucson',
         country: ['AO', 'AR'],
         proximity: [3, 4],
-        types: ['street', 'country', 'region'],
+        types: ['street', 'country', 'region', 'address', 'secondary_address'],
         autocomplete: 'true',
         bbox: [1, 2, 3, 4],
         format: 'v5',
@@ -153,7 +153,7 @@ describe('reverseGeocode', () => {
         limit: 3,
         language: 'de',
         worldview: 'us',
-        permanent: 'true',
+        permanent: 'true'
       }
     });
   });

--- a/services/geocoding-v6.js
+++ b/services/geocoding-v6.js
@@ -23,7 +23,8 @@ var featureTypes = [
   'place',
   'locality',
   'neighborhood',
-  'address'
+  'address',
+  'secondary_address'
 ];
 
 /**
@@ -38,7 +39,7 @@ var featureTypes = [
  *   Each item in the array should be an [ISO 3166 alpha 2 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
  *   [OR] if used with input mode="structured" denotes single country in free form.
  * @param {Coordinates|'ip'} [config.proximity] - Bias local results based on a provided coordinate location or a user's IP address.
- * @param {Array<'street'|'country'|'region'|'postcode'|'district'|'place'|'locality'|'neighborhood'|'address'>} [config.types] - Filter results by feature types.
+ * @param {Array<'street'|'country'|'region'|'postcode'|'district'|'place'|'locality'|'neighborhood'|'address'|'secondary_address'>} [config.types] - Filter results by feature types.
  * @param {BoundingBox} [config.bbox] - Limit results to a bounding box.
  * @param {number} [config.limit=5] - Limit the number of results returned.
  * @param {'geojson'|'v5'} [config.format='geojson'] - Specify the desired response format of results (geojson, default) or for backwards compatibility (v5).
@@ -219,7 +220,7 @@ GeocodingV6.reverseGeocode = function(config) {
     limit: v.number,
     language: v.string,
     worldview: v.string,
-    permanent: v.boolean,
+    permanent: v.boolean
   })(config);
 
   var query = stringifyBooleans(


### PR DESCRIPTION
## Changes
- Adds `secondary_address` to the list of accepted types for the Geocoding v6 service

## Release steps
- [ ] Create and push new tag for v0.15.6
- [ ] Publish as latest release on GitHub with this tag
- [ ] Publish to NPM