### PR TITLE
fix: memory leak caused by storing requestsUnderway indefinitely

### DIFF
--- a/lib/node/node-layer.js
+++ b/lib/node/node-layer.js
@@ -121,6 +121,7 @@ function nodeSend(request) {
           type: constants.ERROR_REQUEST_ABORTED
         });
         errored = true;
+        delete requestsUnderway[request.id];
         reject(mapiError);
       });
 
@@ -145,6 +146,7 @@ function nodeSend(request) {
             body: body,
             statusCode: statusCode
           });
+          delete requestsUnderway[request.id];
           reject(mapiError);
           return;
         }
@@ -155,14 +157,17 @@ function nodeSend(request) {
             headers: httpsResponse.headers,
             statusCode: httpsResponse.statusCode
           });
+          delete requestsUnderway[request.id];
           resolve(response);
         } catch (responseError) {
+          delete requestsUnderway[request.id];
           reject(responseError);
         }
       });
 
       gotStream.on('error', function(error) {
         errored = true;
+        delete requestsUnderway[request.id];
         reject(error);
       });
     });


### PR DESCRIPTION
The requestsUnderway object was only getting cleaned on aborted requests. 

This PR adds cleanup on all resolved and rejected cases.

Fixes: https://github.com/mapbox/mapbox-sdk-js/issues/396