### PR TITLE
fix(node-layer): Fixes file upload handling

### DIFF
--- a/lib/node/node-layer.js
+++ b/lib/node/node-layer.js
@@ -62,7 +62,8 @@ function createRequestStreams(request) {
 
   if (
     ['POST', 'PUT', 'PATCH', 'DELETE'].includes(request.method) &&
-    !request.body
+    !request.body &&
+    !gotOptions.body
   ) {
     gotOptions.body = '';
   }


### PR DESCRIPTION
PR #479 attempted to fix requests where the body was null/undefined by setting the GOT body to an empty string - however, this wiped out the body being set by the file handling cases before this logic.

This commit adds a check to confirm that gotBody is falsy before setting it to an empty string, preserving the file body.

Fixes #486